### PR TITLE
Add worker and muxer tests

### DIFF
--- a/test/mp4muxer.test.ts
+++ b/test/mp4muxer.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Mp4MuxerWrapper } from '../src/mp4muxer';
+import type { EncoderConfig } from '../src/types';
+
+var muxerMethods: any;
+var MuxerMock: any;
+var ArrayBufferTargetMock: any;
+
+vi.mock('mp4-muxer', () => {
+  muxerMethods = {
+    addVideoChunk: vi.fn(),
+    addAudioChunk: vi.fn(),
+    finalize: vi.fn(),
+  };
+  MuxerMock = vi.fn(() => muxerMethods);
+  ArrayBufferTargetMock = vi.fn(function() { this.buffer = new ArrayBuffer(4); });
+  return { Muxer: MuxerMock, ArrayBufferTarget: ArrayBufferTargetMock };
+});
+
+const config: EncoderConfig = {
+  width: 320,
+  height: 240,
+  frameRate: 30,
+  videoBitrate: 1000,
+  audioBitrate: 64,
+  sampleRate: 48000,
+  channels: 2,
+};
+
+describe('Mp4MuxerWrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds video chunks', () => {
+    const wrapper = new Mp4MuxerWrapper(config);
+    const chunk = {} as EncodedVideoChunk;
+    const meta = {} as EncodedVideoChunkMetadata;
+    wrapper.addVideoChunk(chunk, meta);
+    expect(muxerMethods.addVideoChunk).toHaveBeenCalledWith(chunk, meta);
+  });
+
+  it('adds audio chunks', () => {
+    const wrapper = new Mp4MuxerWrapper(config);
+    const chunk = {} as EncodedAudioChunk;
+    const meta = {} as EncodedAudioChunkMetadata;
+    wrapper.addAudioChunk(chunk, meta);
+    expect(muxerMethods.addAudioChunk).toHaveBeenCalledWith(chunk, meta);
+  });
+
+  it('finalizes and returns Uint8Array', () => {
+    const wrapper = new Mp4MuxerWrapper(config);
+    const output = wrapper.finalize();
+    expect(muxerMethods.finalize).toHaveBeenCalled();
+    expect(output).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const config = {
+  width: 160,
+  height: 120,
+  frameRate: 30,
+  videoBitrate: 1000,
+  audioBitrate: 64,
+  sampleRate: 48000,
+  channels: 1,
+};
+
+let postMessage: any;
+let Mp4MuxerWrapperMock: any;
+let addVideoChunk: any;
+let addAudioChunk: any;
+let finalizeMock: any;
+
+beforeEach(async () => {
+  vi.resetModules();
+  postMessage = vi.fn();
+  (global as any).self = { postMessage, onmessage: null } as any;
+  (global as any).postMessage = postMessage;
+
+  addVideoChunk = vi.fn();
+  addAudioChunk = vi.fn();
+  finalizeMock = vi.fn(() => new Uint8Array([1, 2, 3]));
+  Mp4MuxerWrapperMock = vi.fn(() => ({
+    addVideoChunk,
+    addAudioChunk,
+    finalize: finalizeMock,
+  }));
+
+  vi.doMock('../src/mp4muxer', () => ({ Mp4MuxerWrapper: Mp4MuxerWrapperMock }));
+
+  const createEncoder = () => ({
+    configure: vi.fn(),
+    encode: vi.fn(),
+    flush: vi.fn(() => Promise.resolve()),
+    close: vi.fn(),
+  });
+
+  (global as any).VideoEncoder = vi.fn(() => createEncoder());
+  (global as any).AudioEncoder = vi.fn(() => createEncoder());
+  (global as any).VideoFrame = class { constructor(public bitmap: any, public opts: any) {} close() {} };
+  (global as any).AudioData = class { constructor(public opts: any) {} close() {} };
+
+  await import('../src/worker');
+});
+
+afterEach(() => {
+  vi.resetModules();
+  delete (global as any).VideoEncoder;
+  delete (global as any).AudioEncoder;
+  delete (global as any).VideoFrame;
+  delete (global as any).AudioData;
+  delete (global as any).self;
+  delete (global as any).postMessage;
+});
+
+describe('worker', () => {
+  it('initializes and finalizes', async () => {
+    await (global as any).self.onmessage({ data: { type: 'initialize', config } });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'initialized' });
+
+    await (global as any).self.onmessage({ data: { type: 'finalize' } });
+    expect(finalizeMock).toHaveBeenCalled();
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'finalized', output: expect.any(Uint8Array) },
+      expect.any(Object)
+    );
+  });
+
+  it('handles cancel message', async () => {
+    await (global as any).self.onmessage({ data: { type: 'initialize', config } });
+    postMessage.mockClear();
+    await (global as any).self.onmessage({ data: { type: 'cancel' } });
+    expect(postMessage).toHaveBeenCalledWith({ type: 'cancelled' });
+  });
+});


### PR DESCRIPTION
## Summary
- add test coverage for Mp4MuxerWrapper
- add worker test exercising initialize, finalize and cancel paths
- extend encoder tests to handle worker messages and cancellation cases

## Testing
- `npm test`