### PR TITLE
Support null finalized output

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -163,7 +163,7 @@ export class Mp4Encoder {
         }
         break;
       case 'finalized':
-        if (message.output) { // Non-realtime mode or final part of fragmented MP4 with full file
+        if (message.output !== null) { // Non-realtime mode or final part of fragmented MP4 with full file
           this.onFinalizedPromise?.resolve(message.output);
         } else { // Realtime mode, stream finished, no single file output from worker in this message
             if (this.config.latencyMode === 'realtime') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,7 +105,7 @@ export interface ProgressMessage {
 
 export interface WorkerFinalizedMessage {
   type: 'finalized';
-  output: Uint8Array; // MP4 file data
+  output: Uint8Array | null; // MP4 file data or null when streaming
 }
 
 export interface WorkerDataChunkMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -284,9 +284,9 @@ async function handleFinalize(): Promise<void> {
     if (muxer) {
       const output = muxer.finalize();
       if (output) {
-        postMessageToMainThread({ type: 'finalized', output } as MainThreadMessage, [output.buffer]);
+        postMessageToMainThread({ type: 'finalized', output }, [output.buffer]);
       } else if (currentConfig?.latencyMode === 'realtime') {
-        postMessageToMainThread({ type: 'finalized', output: null as any } as MainThreadMessage);
+        postMessageToMainThread({ type: 'finalized', output: null });
       } else {
          postMessageToMainThread({ type: 'error', errorDetail: { message: 'Muxer finalized without output in non-realtime mode.', type: EncoderErrorType.MuxingFailed }});
       }

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -131,14 +131,13 @@ describe('worker', () => {
     mockSelf.postMessage.mockClear(); // Clear previous calls
     const finalizeMessage: FinalizeWorkerMessage = { type: 'finalize' };
     await global.self.onmessage({ data: finalizeMessage } as MessageEvent);
-    // Worker should post a 'finalized' message with the MP4 data
-    expect(mockSelf.postMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ 
-        type: 'finalized',
-        output: expect.any(Uint8Array) // Expect Uint8Array output
-      }), 
-      expect.any(Array) // Expect the transferable list (output.buffer)
-    );
+    // Worker should post a 'finalized' message with the MP4 data or null when streaming
+    expect(mockSelf.postMessage).toHaveBeenCalled();
+    const finalizedCall = mockSelf.postMessage.mock.calls[0];
+    const msg = finalizedCall[0];
+    expect(msg.type).toBe('finalized');
+    expect(msg.output === null || msg.output instanceof Uint8Array).toBe(true);
+    expect(finalizedCall[1]).toEqual(expect.any(Array)); // transferable list
   });
 
   it('handles cancel message', async () => {


### PR DESCRIPTION
## Summary
- allow `WorkerFinalizedMessage` to send `null`
- handle null output in encoder and worker
- update worker tests for union finalized output

## Testing
- `npm test`