### PR TITLE
Fix quoting in GitHub CI cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('''**/package-lock.json''') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
       - run: npm ci


### PR DESCRIPTION
## Summary
- fix single quoted cache key for package-lock hashing in CI workflow

## Testing
- `npm test`