### PR TITLE
Add actual codec reporting

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -26,6 +26,8 @@ export class Mp4Encoder {
   private worker: Worker | null = null;
   private totalFrames: number | undefined;
   private processedFramesInternal: number = 0;
+  private actualVideoCodec: string | null = null;
+  private actualAudioCodec: string | null = null;
 
   // Callbacks for asynchronous operations
   private onInitialized: ((value: void | PromiseLike<void>) => void) | null = null;
@@ -142,6 +144,8 @@ export class Mp4Encoder {
 
     switch (message.type) {
       case 'initialized':
+        this.actualVideoCodec = (message as any).actualVideoCodec ?? null;
+        this.actualAudioCodec = (message as any).actualAudioCodec ?? null;
         this.onInitialized?.();
         this.onInitialized = null;
         this.onInitializeError = null;
@@ -381,5 +385,13 @@ export class Mp4Encoder {
         console.log('Mp4Encoder: Worker references cleaned up after worker error.');
     }
     this.isCancelled = true;
+  }
+
+  public getActualVideoCodec(): string | null {
+    return this.actualVideoCodec;
+  }
+
+  public getActualAudioCodec(): string | null {
+    return this.actualAudioCodec;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,8 @@ export type WorkerMessage =
 // Messages FROM the Worker
 export interface WorkerInitializedMessage {
   type: 'initialized';
+  actualVideoCodec?: string;
+  actualAudioCodec?: string;
 }
 
 export interface VideoChunkMessage { // Primarily for internal use or advanced scenarios

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -189,8 +189,10 @@ async function initializeEncoders(data: InitializeWorkerMessage): Promise<void> 
     return;
   }
 
-  postMessageToMainThread({ 
+  postMessageToMainThread({
     type: 'initialized',
+    actualVideoCodec: finalVideoEncoderConfig?.codec,
+    actualAudioCodec: finalAudioEncoderConfig?.codec,
   } as MainThreadMessage);
 }
 

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -57,7 +57,7 @@ describe('worker', () => {
         state: 'unconfigured',
     }));
     // @ts-ignore
-    mockSelf.VideoEncoder.isConfigSupported = vi.fn(() => Promise.resolve({ supported: true, config: {} }));
+    mockSelf.VideoEncoder.isConfigSupported = vi.fn(() => Promise.resolve({ supported: true, config: { codec: 'avc1.42001f' } }));
 
     // @ts-ignore
     mockSelf.AudioEncoder = vi.fn(() => ({
@@ -68,7 +68,7 @@ describe('worker', () => {
         state: 'unconfigured',
     }));
     // @ts-ignore
-    mockSelf.AudioEncoder.isConfigSupported = vi.fn(() => Promise.resolve({ supported: true, config: {} }));
+    mockSelf.AudioEncoder.isConfigSupported = vi.fn(() => Promise.resolve({ supported: true, config: { codec: 'mp4a.40.2' } }));
 
     // Make worker-internal mocks also available on globalThis for the helper functions in worker.ts
     globalThis.VideoEncoder = mockSelf.VideoEncoder;
@@ -125,7 +125,10 @@ describe('worker', () => {
     // Simulate receiving an initialize message
     const initMessage: InitializeWorkerMessage = { type: 'initialize', config };
     await global.self.onmessage({ data: initMessage } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith({ type: 'initialized' }, undefined);
+    expect(mockSelf.postMessage).toHaveBeenCalledWith(
+      { type: 'initialized', actualVideoCodec: 'avc1.42001f', actualAudioCodec: 'mp4a.40.2' },
+      undefined
+    );
 
     // Simulate receiving a finalize message
     mockSelf.postMessage.mockClear(); // Clear previous calls
@@ -147,7 +150,10 @@ describe('worker', () => {
     // Initialize first (or part of it, enough to set up for cancel)
     const initMessage: InitializeWorkerMessage = { type: 'initialize', config };
     await global.self.onmessage({ data: initMessage } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith({ type: 'initialized' }, undefined);
+    expect(mockSelf.postMessage).toHaveBeenCalledWith(
+      { type: 'initialized', actualVideoCodec: 'avc1.42001f', actualAudioCodec: 'mp4a.40.2' },
+      undefined
+    );
     mockSelf.postMessage.mockClear();
 
     // Simulate receiving a cancel message


### PR DESCRIPTION
## Summary
- extend `WorkerInitializedMessage` with `actualVideoCodec` and `actualAudioCodec`
- return these codec strings from worker when encoders are configured
- store codec info in `Mp4Encoder` and expose getters
- update streaming README example
- test reporting of actual codecs

## Testing
- `npm test`