### PR TITLE
Preserve worker cancelled state

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -495,11 +495,11 @@ function handleCancel(_message: CancelWorkerMessage): void {
   console.log("Worker: Received cancel signal.");
   videoEncoder?.close();
   audioEncoder?.close();
-  cleanup();
+  cleanup(false);
   postMessageToMainThread({ type: "cancelled" } as MainThreadMessage);
 }
 
-function cleanup(): void {
+function cleanup(resetCancelled: boolean = true): void {
   console.log("Worker: Cleaning up resources.");
   if (videoEncoder && videoEncoder.state !== "closed") videoEncoder.close();
   if (audioEncoder && audioEncoder.state !== "closed") audioEncoder.close();
@@ -509,7 +509,9 @@ function cleanup(): void {
   currentConfig = null;
   totalFramesToProcess = undefined;
   processedFrames = 0;
-  isCancelled = false;
+  if (resetCancelled) {
+    isCancelled = false;
+  }
 }
 
 self.onmessage = async (event: MessageEvent<WorkerMessage>) => {

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -188,7 +188,24 @@ describe("worker", () => {
       { type: "cancelled" },
       undefined,
     );
-    // Optionally, check if encoders/muxer were closed if the mock allows that level of detail
+
+    // After cancellation, other messages should be ignored
+    mockSelf.postMessage.mockClear();
+    const finalizeMessage: FinalizeWorkerMessage = { type: "finalize" };
+    await global.self.onmessage({ data: finalizeMessage } as MessageEvent);
+    expect(mockSelf.postMessage).not.toHaveBeenCalled();
+
+    // Reinitialize should reset the cancelled state
+    const initMessage2: InitializeWorkerMessage = { type: "initialize", config };
+    await global.self.onmessage({ data: initMessage2 } as MessageEvent);
+    expect(mockSelf.postMessage).toHaveBeenCalledWith(
+      {
+        type: "initialized",
+        actualVideoCodec: "avc1.42001f",
+        actualAudioCodec: "mp4a.40.2",
+      },
+      undefined,
+    );
   });
 
   // Add more tests for addVideoData, addAudioData, error handling, etc.


### PR DESCRIPTION
## Summary
- keep `isCancelled` true when `cleanup` runs during cancel
- ignore further messages after cancelling
- add test to verify cancellation state persistence

## Testing
- `npm test`