### PR TITLE
Make totalFrames optional

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -14,7 +14,7 @@ export type RealtimeDataCallback = (
 ) => void;
 
 export interface Mp4EncoderInitializeOptions {
-  onProgress?: (processedFrames: number, totalFrames: number) => void;
+  onProgress?: (processedFrames: number, totalFrames?: number) => void;
   totalFrames?: number;
   onError?: (error: Mp4EncoderError) => void;
   onData?: RealtimeDataCallback;
@@ -37,7 +37,7 @@ export class Mp4Encoder {
     reject: (reason?: any) => void;
   } | null = null;
   private onProgressCallback:
-    | ((processedFrames: number, totalFrames: number) => void)
+    | ((processedFrames: number, totalFrames?: number) => void)
     | null = null;
   private onErrorCallback: ((error: Mp4EncoderError) => void) | null = null;
   private onDataCallback: RealtimeDataCallback | null = null; // For real-time data

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface EncoderConfig {
 
 export type ProgressCallback = (
   processedFrames: number,
-  totalFrames: number,
+  totalFrames?: number,
 ) => void;
 
 // --- Custom Error for the library ---
@@ -111,7 +111,7 @@ export interface AudioChunkMessage {
 export interface ProgressMessage {
   type: "progress";
   processedFrames: number;
-  totalFrames: number;
+  totalFrames?: number;
 }
 
 export interface WorkerFinalizedMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -350,13 +350,14 @@ async function handleAddVideoFrame(data: AddVideoFrameMessage): Promise<void> {
     videoEncoder.encode(frame);
     frame.close();
     processedFrames++;
-    if (totalFramesToProcess) {
-      postMessageToMainThread({
-        type: "progress",
-        processedFrames,
-        totalFrames: totalFramesToProcess,
-      } as MainThreadMessage);
+    const progressMessage: any = {
+      type: "progress",
+      processedFrames,
+    };
+    if (typeof totalFramesToProcess !== "undefined") {
+      progressMessage.totalFrames = totalFramesToProcess;
     }
+    postMessageToMainThread(progressMessage as MainThreadMessage);
   } catch (error: any) {
     postMessageToMainThread({
       type: "error",

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -431,8 +431,12 @@ describe("Mp4Encoder", () => {
         mockWorkerInstance.onmessage({
           data: { type: "progress", processedFrames: 10, totalFrames: 100 },
         });
+        mockWorkerInstance.onmessage({
+          data: { type: "progress", processedFrames: 20 },
+        });
       }
-      expect(onProgress).toHaveBeenCalledWith(10, 100);
+      expect(onProgress).toHaveBeenNthCalledWith(1, 10, 100);
+      expect(onProgress).toHaveBeenNthCalledWith(2, 20, undefined);
     });
   });
 


### PR DESCRIPTION
## Summary
- make `totalFrames` optional in `ProgressCallback`
- make `ProgressMessage.totalFrames` optional
- propagate optional progress values in encoder and worker
- update tests for optional `totalFrames`

## Testing
- `npm test`