### PR TITLE
Add AudioData transfer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ async function encodeVideoRealtime() {
       }
 
       // For real-time audio, you would continuously call addAudioBuffer
+      // or addAudioData when you already have AudioData chunks
       // For this example, we'll add a silent track matching video duration after frames.
       // In a true real-time scenario, audio and video would be interleaved.
       const audioContext = new AudioContext({ sampleRate: config.sampleRate });

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,9 @@ export interface AddAudioDataMessage {
   type: "addAudioData";
   // Array of Float32Array for each channel (non-interleaved).
   // The ArrayBuffer of each Float32Array should be transferred.
-  audioData: Float32Array[];
+  audioData?: Float32Array[];
+  /** Optional AudioData object to be encoded directly. */
+  audio?: AudioData;
   timestamp: number; // microseconds
   format: AudioSampleFormat; // e.g., "f32-planar" or "s16" etc. (AudioSampleFormat from WebCodecs)
   sampleRate: number;


### PR DESCRIPTION
## Summary
- allow `AddAudioDataMessage` to hold `AudioData`
- implement `Mp4Encoder.addAudioData()` for sending `AudioData`
- handle optional `AudioData` in worker
- document real-time audio workflow
- test new method and worker branch

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`