### PR TITLE
Add advanced worker configuration and audio worklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) usin
 - Encodes `AudioBuffer` to AAC or Opus audio.
 - Muxes encoded video and audio into a standard MP4 file.
 - Real-time streaming: Delivers muxed data in chunks via a callback, suitable for live streaming with Media Source Extensions (MSE).
+- Optional AudioWorklet path for piping audio directly to the worker to reduce main-thread latency.
 - Uses Web Workers to offload encoding tasks from the main thread.
 - Provides progress callbacks and cancellation support.
 - Built with TypeScript, providing type definitions.
@@ -287,6 +288,9 @@ async function encodeVideoRealtime() {
     - `totalFrames?: number`: Total number of video frames to be encoded. Used for progress calculation.
     - `onError?: (error: Mp4EncoderError) => void`: Callback for errors occurring in the worker after initialization. Receives an `Mp4EncoderError` object.
     - `onData?: (chunk: Uint8Array, isHeader?: boolean) => void`: Callback for receiving muxed data chunks. Used when `latencyMode` is `'realtime'`. `isHeader` is true for the initial MP4 header chunk.
+    - `worker?: Worker`: Provide a pre-created `Worker` instance instead of letting `Mp4Encoder` create one.
+    - `workerScriptUrl?: string | URL`: Specify a custom worker script to load when creating the worker.
+    - `useAudioWorklet?: boolean`: Use an `AudioWorklet` to pipe audio data directly to the worker for lower latency.
 
 - **`encoder.addVideoFrame(frame: VideoFrame): Promise<void>`**
   Adds a `VideoFrame` object for encoding. Ensure the source is converted to a `VideoFrame` before calling this method.

--- a/src/audio-worklet-processor.ts
+++ b/src/audio-worklet-processor.ts
@@ -1,0 +1,59 @@
+declare const sampleRate: number;
+
+declare function registerProcessor(
+  name: string,
+  processorCtor: typeof AudioWorkletProcessor,
+): void;
+
+declare class AudioWorkletProcessor {
+  readonly port: MessagePort;
+  constructor();
+  process(
+    inputs: Float32Array[][],
+    outputs: Float32Array[][],
+    parameters: Record<string, Float32Array>,
+  ): boolean;
+}
+
+class EncoderAudioWorkletProcessor extends AudioWorkletProcessor {
+  private workerPort: MessagePort | null = null;
+  private sampleRateVal = sampleRate;
+  constructor() {
+    super();
+    this.port.onmessage = (event) => {
+      if (event.data?.port) {
+        this.workerPort = event.data.port as MessagePort;
+      }
+      if (event.data?.sampleRate) {
+        this.sampleRateVal = event.data.sampleRate;
+      }
+    };
+  }
+  process(inputs: Float32Array[][]) {
+    if (!this.workerPort) return true;
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+    const numChannels = input.length;
+    const numFrames = input[0].length;
+    const buffers: Float32Array[] = [];
+    for (let c = 0; c < numChannels; c++) {
+      const copy = new Float32Array(input[c]);
+      buffers.push(copy);
+    }
+    this.workerPort.postMessage(
+      {
+        type: "addAudioData",
+        audioData: buffers,
+        numberOfFrames: numFrames,
+        numberOfChannels: numChannels,
+        sampleRate: this.sampleRateVal,
+        timestamp: 0,
+        format: "f32-planar",
+      },
+      buffers.map((b) => b.buffer),
+    );
+    return true;
+  }
+}
+
+registerProcessor("encoder-audio-worklet", EncoderAudioWorkletProcessor);

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -15,6 +15,9 @@ export interface Mp4EncoderInitializeOptions {
   totalFrames?: number;
   onError?: (error: Mp4EncoderError) => void;
   onData?: RealtimeDataCallback;
+  worker?: Worker;
+  workerScriptUrl?: string | URL;
+  useAudioWorklet?: boolean;
 }
 
 export class Mp4Encoder {
@@ -42,6 +45,8 @@ export class Mp4Encoder {
   private isCancelled: boolean = false;
   private nextVideoTimestamp: number = 0;
   private nextAudioTimestamp: number = 0;
+  private audioContext: AudioContext | null = null;
+  private audioWorkletNode: AudioWorkletNode | null = null;
 
   constructor(config: EncoderConfig) {
     this.config = {
@@ -122,44 +127,55 @@ export class Mp4Encoder {
     return new Promise<void>((resolve, reject) => {
       this.onInitialized = resolve;
       this.onInitializeError = reject;
+      const start = async () => {
+        try {
+          if (options?.worker) {
+            this.worker = options.worker;
+          } else {
+            const script =
+              options?.workerScriptUrl ??
+              new URL("./worker.js", import.meta.url);
+            this.worker = new Worker(script as any, { type: "module" });
+          }
 
-      try {
-        this.worker = new Worker(new URL("./worker.js", import.meta.url), {
-          type: "module",
-        });
+          this.worker.onmessage = (event: MessageEvent<MainThreadMessage>) => {
+            this.handleWorkerMessage(event.data);
+          };
 
-        this.worker.onmessage = (event: MessageEvent<MainThreadMessage>) => {
-          this.handleWorkerMessage(event.data);
-        };
+          this.worker.onerror = (event: ErrorEvent) => {
+            const err = new Mp4EncoderError(
+              EncoderErrorType.WorkerError,
+              `Worker error: ${event.message || "Unknown worker error"}`,
+              event,
+            );
+            this.handleError(err);
+            this.onInitializeError?.(err);
+            this.onFinalizedPromise?.reject(err);
+            this.cleanupWorkerOnError();
+          };
 
-        this.worker.onerror = (event: ErrorEvent) => {
+          if (options?.useAudioWorklet) {
+            await this.setupAudioWorklet();
+          }
+
+          const initMessage: WorkerMessage = {
+            type: "initialize",
+            config: this.config, // Pass updated config
+            totalFrames: this.totalFrames,
+          };
+          this.worker.postMessage(initMessage);
+        } catch (e: any) {
           const err = new Mp4EncoderError(
-            EncoderErrorType.WorkerError,
-            `Worker error: ${event.message || "Unknown worker error"}`,
-            event,
+            EncoderErrorType.InitializationFailed,
+            `Failed to initialize worker: ${e.message}`,
+            e,
           );
           this.handleError(err);
           this.onInitializeError?.(err);
-          this.onFinalizedPromise?.reject(err);
           this.cleanupWorkerOnError();
-        };
-
-        const initMessage: WorkerMessage = {
-          type: "initialize",
-          config: this.config, // Pass updated config
-          totalFrames: this.totalFrames,
-        };
-        this.worker.postMessage(initMessage);
-      } catch (e: any) {
-        const err = new Mp4EncoderError(
-          EncoderErrorType.InitializationFailed,
-          `Failed to initialize worker: ${e.message}`,
-          e,
-        );
-        this.handleError(err);
-        this.onInitializeError?.(err);
-        this.cleanupWorkerOnError();
-      }
+        }
+      };
+      void start();
     });
   }
 
@@ -436,6 +452,15 @@ export class Mp4Encoder {
       this.worker = null;
       logger.log("Mp4Encoder: Worker terminated and cleaned up.");
     }
+    if (this.audioWorkletNode) {
+      this.audioWorkletNode.port.postMessage({ close: true });
+      this.audioWorkletNode.disconnect();
+      this.audioWorkletNode = null;
+    }
+    if (this.audioContext) {
+      this.audioContext.close();
+      this.audioContext = null;
+    }
     this.isCancelled = true; // Ensure isCancelled is true after cleanup
   }
 
@@ -452,6 +477,41 @@ export class Mp4Encoder {
       );
     }
     this.isCancelled = true;
+  }
+
+  private async setupAudioWorklet(): Promise<void> {
+    const AudioContextCtor: any = (globalThis as any).AudioContext;
+    if (!AudioContextCtor) {
+      const err = new Mp4EncoderError(
+        EncoderErrorType.NotSupported,
+        "AudioContext not available for AudioWorklet.",
+      );
+      this.handleError(err);
+      throw err;
+    }
+
+    this.audioContext = new AudioContextCtor({
+      sampleRate: this.config.sampleRate,
+    });
+    await this.audioContext!.audioWorklet.addModule(
+      new URL("./audio-worklet-processor.js", import.meta.url),
+    );
+    this.audioWorkletNode = new AudioWorkletNode(
+      this.audioContext!,
+      "encoder-audio-worklet",
+      { numberOfInputs: 1, numberOfOutputs: 0 },
+    );
+
+    const { port1, port2 } = new MessageChannel();
+    const connectMessage: WorkerMessage = {
+      type: "connectAudioPort",
+      port: port1,
+    } as any;
+    this.worker!.postMessage(connectMessage, [port1]);
+    this.audioWorkletNode.port.postMessage(
+      { port: port2, sampleRate: this.config.sampleRate },
+      [port2],
+    );
   }
 
   public getActualVideoCodec(): string | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,12 +84,18 @@ export interface CancelWorkerMessage {
   type: "cancel";
 }
 
+export interface ConnectAudioPortMessage {
+  type: "connectAudioPort";
+  port: MessagePort;
+}
+
 export type WorkerMessage =
   | InitializeWorkerMessage
   | AddVideoFrameMessage
   | AddAudioDataMessage
   | FinalizeWorkerMessage
-  | CancelWorkerMessage;
+  | CancelWorkerMessage
+  | ConnectAudioPortMessage;
 
 // Messages FROM the Worker
 export interface WorkerInitializedMessage {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,6 +19,7 @@ let currentConfig: EncoderConfig | null = null;
 let totalFramesToProcess: number | undefined;
 let processedFrames: number = 0;
 let isCancelled: boolean = false;
+let audioWorkletPort: MessagePort | null = null;
 
 // --- 追加: グローバル API を安全に取るヘルパ ---
 const getVideoEncoder = () =>
@@ -515,6 +516,11 @@ function cleanup(resetCancelled: boolean = true): void {
   currentConfig = null;
   totalFramesToProcess = undefined;
   processedFrames = 0;
+  if (audioWorkletPort) {
+    audioWorkletPort.onmessage = null;
+    audioWorkletPort.close();
+    audioWorkletPort = null;
+  }
   if (resetCancelled) {
     isCancelled = false;
   }
@@ -538,6 +544,15 @@ self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
         isCancelled = false;
         cleanup();
         await initializeEncoders(event.data);
+        break;
+      case "connectAudioPort":
+        audioWorkletPort = event.data.port;
+        audioWorkletPort.onmessage = async (
+          e: MessageEvent<AddAudioDataMessage>,
+        ) => {
+          if (isCancelled) return;
+          await handleAddAudioData(e.data);
+        };
         break;
       case "addVideoFrame":
         if (isCancelled) break;

--- a/test/worker.test.ts
+++ b/test/worker.test.ts
@@ -190,6 +190,33 @@ describe("worker", () => {
     expect(transferredObject).toBe(expectedOutputArray.buffer);
   });
 
+  it("connects audio port and handles messages", async () => {
+    if (!global.self.onmessage)
+      throw new Error("Worker onmessage handler not set up");
+    const port: any = { postMessage: vi.fn(), onmessage: null, close: vi.fn() };
+    const initMessage: InitializeWorkerMessage = { type: "initialize", config };
+    await global.self.onmessage({ data: initMessage } as MessageEvent);
+    const connectMsg = { type: "connectAudioPort", port } as any;
+    await global.self.onmessage({ data: connectMsg } as MessageEvent);
+    expect(port.onmessage).toBeTypeOf("function");
+    mockSelf.AudioEncoder.mock.results[0].value.encode.mockClear();
+
+    const addAudioMsg: AddAudioDataMessage = {
+      type: "addAudioData",
+      audioData: [new Float32Array(1), new Float32Array(1)],
+      timestamp: 0,
+      format: "f32-planar",
+      sampleRate: config.sampleRate,
+      numberOfFrames: 1,
+      numberOfChannels: 2,
+    };
+    if (port.onmessage)
+      await port.onmessage({ data: addAudioMsg } as MessageEvent);
+    expect(
+      mockSelf.AudioEncoder.mock.results[0].value.encode,
+    ).toHaveBeenCalled();
+  });
+
   it("handles cancel message", async () => {
     if (!global.self.onmessage) {
       throw new Error("Worker onmessage handler not set up by script import");


### PR DESCRIPTION
## Summary
- add ability to pass custom worker or script URL when initializing `Mp4Encoder`
- prototype `AudioWorklet` integration for low latency audio
- document advanced initialization options
- test worker injection and audio worklet path

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
