### PR TITLE
Fix cleanup after stopping MediaStreamRecorder

### DIFF
--- a/src/mediastream-recorder.ts
+++ b/src/mediastream-recorder.ts
@@ -84,6 +84,10 @@ export class MediaStreamRecorder {
     this.audioReader?.cancel();
     this.videoTrack?.stop();
     this.audioTrack?.stop();
+    this.videoReader = undefined;
+    this.audioReader = undefined;
+    this.videoTrack = undefined;
+    this.audioTrack = undefined;
     return await this.encoder.finalize();
   }
 
@@ -94,6 +98,10 @@ export class MediaStreamRecorder {
     this.audioReader?.cancel();
     this.videoTrack?.stop();
     this.audioTrack?.stop();
+    this.videoReader = undefined;
+    this.audioReader = undefined;
+    this.videoTrack = undefined;
+    this.audioTrack = undefined;
     this.encoder.cancel();
   }
 


### PR DESCRIPTION
## Summary
- reset MediaStreamRecorder reader and track references once stopped or cancelled

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
