### PR TITLE
Fix frame closing in MediaStreamRecorder

### DIFF
--- a/src/mediastream-recorder.ts
+++ b/src/mediastream-recorder.ts
@@ -61,7 +61,6 @@ export class MediaStreamRecorder {
       const { value, done } = await this.videoReader.read();
       if (done || !value) break;
       await this.encoder.addVideoFrame(value);
-      if (typeof value.close === "function") value.close();
     }
   }
 
@@ -71,7 +70,6 @@ export class MediaStreamRecorder {
       const { value, done } = await this.audioReader.read();
       if (done || !value) break;
       await this.encoder.addAudioData(value);
-      if (typeof value.close === "function") value.close();
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid closing frames in `MediaStreamRecorder`

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
