### PR TITLE
Ensure AudioData closed after encoding

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -437,7 +437,7 @@ async function handleAddAudioData(data: AddAudioDataMessage): Promise<void> {
 
     const interleavedData = interleaveFloat32Arrays(data.audioData);
 
-    const audioData = new AudioDataCtor({
+    const audioData: AudioData = new AudioDataCtor({
       format: "f32", // インターリーブしたので 'f32'
       sampleRate: data.sampleRate,
       numberOfFrames: data.numberOfFrames,
@@ -445,8 +445,11 @@ async function handleAddAudioData(data: AddAudioDataMessage): Promise<void> {
       timestamp: data.timestamp,
       data: interleavedData.buffer, // インターリーブされたデータの ArrayBuffer を渡す
     });
-
-    audioEncoder.encode(audioData);
+    try {
+      audioEncoder.encode(audioData);
+    } finally {
+      audioData.close();
+    }
   } catch (error: any) {
     postMessageToMainThread({
       type: "error",

--- a/test/worker-audio.test.ts
+++ b/test/worker-audio.test.ts
@@ -156,6 +156,28 @@ describe("handleAddAudioData", () => {
     expect((globalThis as any).AudioData).not.toHaveBeenCalled();
   });
 
+  it("should close AudioData after encoding when created internally", async () => {
+    if (!global.self.onmessage) throw new Error("Worker onmessage handler not set up");
+
+    const dummyAudioSamples = new Float32Array(512);
+    const audioDataArray: Float32Array[] = [];
+    for (let i = 0; i < config.channels; i++) {
+      audioDataArray.push(dummyAudioSamples.slice());
+    }
+
+    const addAudioMessage: AddAudioDataMessage = {
+      type: "addAudioData",
+      audioData: audioDataArray,
+      timestamp: 0,
+      format: "f32-planar",
+      sampleRate: config.sampleRate,
+      numberOfFrames: 512,
+      numberOfChannels: config.channels,
+    };
+    await global.self.onmessage({ data: addAudioMessage } as MessageEvent);
+    expect(mockAudioDataInstance.close).toHaveBeenCalled();
+  });
+
   it("should post error if AudioData API is not available", async () => {
     if (!global.self.onmessage) throw new Error("Worker onmessage handler not set up");
     const AudioDataOriginal = (globalThis as any).AudioData;


### PR DESCRIPTION
## Summary
- release AudioData buffers in worker after encoding
- test that AudioData is closed when worker creates it

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
