### PR TITLE
Implement frame tracking in audio worklet

### DIFF
--- a/src/audio-worklet-processor.ts
+++ b/src/audio-worklet-processor.ts
@@ -18,6 +18,7 @@ declare class AudioWorkletProcessor {
 class EncoderAudioWorkletProcessor extends AudioWorkletProcessor {
   private workerPort: MessagePort | null = null;
   private sampleRateVal = sampleRate;
+  private processedFrames = 0;
   constructor() {
     super();
     this.port.onmessage = (event) => {
@@ -45,6 +46,8 @@ class EncoderAudioWorkletProcessor extends AudioWorkletProcessor {
       const copy = new Float32Array(input[c]);
       buffers.push(copy);
     }
+    const timestamp = (this.processedFrames / this.sampleRateVal) * 1_000_000;
+    this.processedFrames += numFrames;
     this.workerPort.postMessage(
       {
         type: "addAudioData",
@@ -52,7 +55,7 @@ class EncoderAudioWorkletProcessor extends AudioWorkletProcessor {
         numberOfFrames: numFrames,
         numberOfChannels: numChannels,
         sampleRate: this.sampleRateVal,
-        timestamp: 0,
+        timestamp,
         format: "f32-planar",
       },
       buffers.map((b) => b.buffer),

--- a/test/audio-worklet-processor.test.ts
+++ b/test/audio-worklet-processor.test.ts
@@ -191,5 +191,23 @@ describe("EncoderAudioWorkletProcessor", () => {
       expect(actualAudioData[1]).toEqual(expectedBuffers[1]);
       expect(actualAudioData[0]).not.toBe(inputData[0]);
     });
+
+    it("should increment timestamp based on processed frames", () => {
+      const input1 = [new Float32Array([0.1, 0.2])];
+      const input2 = [new Float32Array([0.3, 0.4, 0.5])];
+      processor.sampleRateVal = 48000;
+
+      processor.process([input1], [], {});
+      const timestampFirst =
+        mockWorkerSidePort.postMessage.mock.calls[0][0].timestamp;
+      expect(timestampFirst).toBe(0);
+      mockWorkerSidePort.postMessage.mockClear();
+
+      processor.process([input2], [], {});
+      const expectedTimestampSecond = (input1[0].length / 48000) * 1_000_000;
+      const timestampSecond =
+        mockWorkerSidePort.postMessage.mock.calls[0][0].timestamp;
+      expect(timestampSecond).toBeCloseTo(expectedTimestampSecond);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- keep count of processed frames in `EncoderAudioWorkletProcessor`
- compute timestamp for each packet based on frames and sample rate
- test timestamp progression in worklet

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`