### PR TITLE
Clarify WebM status and enforce check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebCodecs MP4/WebM Encoder (MP4 Muxer Currently)
 
-A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) using the WebCodecs API and mux them into an MP4 container. WebM container support is planned for future versions.
+A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) using the WebCodecs API and mux them into an MP4 container. **WebM output is not yet supported.**
 
 ## Features
 
@@ -13,7 +13,7 @@ A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) usin
 - Provides progress callbacks and cancellation support.
 - Built with TypeScript, providing type definitions.
 - Automatic codec fallback (e.g., VP9 to AVC, Opus to AAC) if the preferred codec is not supported.
-- **WebM Container Support (β)**: Basic WebM muxing is available via `container: 'webm'` option. However, in the current version, specifying `'webm'` may result in a warning, and the content might still be processed as MP4 or an error may occur in the worker if it's not fully supported. Full WebM support with appropriate EBML structure and codec combinations (typically VP9/Opus) is a goal for future versions. MP4 remains the default and most stable option.
+ - **WebM Container Support**: WebM output is not yet implemented. Setting `container: 'webm'` will throw an error during initialization.
 
 ## Installation
 
@@ -278,7 +278,7 @@ const result = await recorder.stopRecording();
 - **`new Mp4Encoder(config: EncoderConfig)`**
   Creates a new encoder instance.
   `EncoderConfig`:
-    - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. See "WebM Container Support" section for details on 'webm'.
+    - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Setting `'webm'` will throw an error as WebM output is not yet supported.
     - `latencyMode?: 'quality' | 'realtime'`: (Optional) Encoding latency mode. `'quality'` (default) for best quality, `'realtime'` for lower latency and chunked output.
     - `width: number`: Video width.
     - `height: number`: Video height.

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -62,12 +62,10 @@ export class Mp4Encoder {
     };
 
     if (this.config.container === "webm") {
-      // Early warning, though worker will also send an error
+      // Early warning for unsupported container
       console.warn(
-        "Mp4Encoder: WebM container is specified but not supported in this version. MP4 will be used or an error will occur in the worker.",
+        "Mp4Encoder: WebM container output is not yet supported and will cause an error during initialization.",
       );
-      // Depending on strictness, could throw here or let worker handle container choice.
-      // For now, let it pass to worker which will error out if it only supports mp4.
     }
 
     // Initialize worker later, only if supported and initialize() is called.
@@ -99,6 +97,15 @@ export class Mp4Encoder {
       // and this.onErrorCallback will be called by the caller if they wish.
       // this.handleError(err);
       throw err; // Throw immediately
+    }
+
+    if (this.config.container === "webm") {
+      const err = new Mp4EncoderError(
+        EncoderErrorType.NotSupported,
+        "WebM container output is not yet supported.",
+      );
+      this.handleError(err);
+      throw err;
     }
 
     if (!Mp4Encoder.isSupported()) {


### PR DESCRIPTION
## Summary
- document that WebM output isn't implemented yet
- warn when a WebM container is requested and throw during initialization

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
