### PR TITLE
Expose codec string overrides and derive profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ const result = await recorder.stopRecording();
     - `sampleRate: number`: Audio sample rate (e.g., 44100, 48000). 48000 is recommended for Opus.
     - `channels: number`: Number of audio channels (e.g., 1 for mono, 2 for stereo).
     - `codec?: { video?: 'avc' | 'hevc' | 'vp9' | 'av1'; audio?: 'aac' | 'opus' }`: (Optional) Preferred codecs. Defaults to `{ video: 'avc', audio: 'aac' }`.
+    - `codecString?: { video?: string; audio?: string }`: (Optional) Explicit codec strings for the encoders. If omitted for H.264, a profile/level is derived from the resolution and frame rate.
 
 - **`encoder.initialize(options?: Mp4EncoderInitializeOptions): Promise<void>`**
   Initializes the encoder and worker.

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ export interface EncoderConfig {
     video?: "avc" | "hevc" | "vp9" | "av1"; // Default: 'avc' (H.264)
     audio?: "aac" | "opus"; // Default: 'aac'
   };
+  /**
+   * Optional codec string overrides passed directly to the encoders.
+   * For example: `{ video: 'avc1.640028', audio: 'mp4a.40.2' }`.
+   */
+  codecString?: {
+    video?: string;
+    audio?: string;
+  };
   latencyMode?: "quality" | "realtime"; // Default: 'quality'
   /** Total frames for progress calculation if known in advance. */
   totalFrames?: number;


### PR DESCRIPTION
## Summary
- allow explicit codec strings in `EncoderConfig`
- derive default AVC profile/level if not provided
- honour codec string overrides in worker
- document new config field
- test overrides and derived AVC level

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
