### PR TITLE
Add audio disable logic

### DIFF
--- a/test/mp4muxer.test.ts
+++ b/test/mp4muxer.test.ts
@@ -256,6 +256,20 @@ describe("Mp4MuxerWrapper", () => {
     });
   });
 
+  describe("audio disabled", () => {
+    it("should omit audio track when disableAudio is true", () => {
+      const wrapper = new Mp4MuxerWrapper(baseConfig, postMessageCallback, {
+        disableAudio: true,
+      });
+      const callArgs = MuxerMock.mock.calls[0][0] as any;
+      expect(callArgs.audio).toBeUndefined();
+
+      mockMuxerMethods.addAudioChunk.mockClear();
+      wrapper.addAudioChunk({} as any, {} as any);
+      expect(mockMuxerMethods.addAudioChunk).not.toHaveBeenCalled();
+    });
+  });
+
   describe("realtime mode (StreamTarget)", () => {
     it("should use StreamTarget and fragmented fastStart in realtime mode", () => {
       const realtimeConfig: EncoderConfig = {

--- a/test/worker-audio.test.ts
+++ b/test/worker-audio.test.ts
@@ -117,8 +117,11 @@ describe("handleAddAudioData", () => {
       type: "initialize",
       config,
     };
+    const beforeCalls = mockSelf.AudioEncoder.mock.calls.length;
     await global.self.onmessage({ data: initMessage } as MessageEvent);
     mockSelf.postMessage.mockClear();
+    mockMuxerInstanceForWorker.addAudioChunk.mockClear();
+    expect(mockSelf.AudioEncoder.mock.calls.length).toBe(beforeCalls);
 
     const dummyAudioSamples = new Float32Array(512);
     const audioDataArray: Float32Array[] = [];
@@ -137,6 +140,7 @@ describe("handleAddAudioData", () => {
     };
     await global.self.onmessage({ data: addAudioMessage } as MessageEvent);
     expect(mockSelf.postMessage).not.toHaveBeenCalled();
+    expect(mockMuxerInstanceForWorker.addAudioChunk).not.toHaveBeenCalled();
   });
 
   it("should encode provided AudioData when audio field is set", async () => {

--- a/test/worker-init.test.ts
+++ b/test/worker-init.test.ts
@@ -218,6 +218,26 @@ describe("worker", () => {
     );
   });
 
+  it("disables audio when audio parameters are invalid", async () => {
+    if (!global.self.onmessage)
+      throw new Error("Worker onmessage handler not set up");
+
+    const invalid = { ...config, audioBitrate: 0 };
+    const initMessage: InitializeWorkerMessage = { type: "initialize", config: invalid };
+    await global.self.onmessage({ data: initMessage } as MessageEvent);
+
+    expect(mockSelf.AudioEncoder).not.toHaveBeenCalled();
+    expect(Mp4MuxerWrapperMock).toHaveBeenCalledWith(
+      invalid,
+      expect.any(Function),
+      { disableAudio: true },
+    );
+    expect(mockSelf.postMessage).toHaveBeenCalledWith(
+      { type: "initialized", actualVideoCodec: "avc1.42001f", actualAudioCodec: null },
+      undefined,
+    );
+  });
+
   // Add more tests for addVideoData, addAudioData, error handling, etc.
   describe("worker error handling during initialization", () => {
     it("should post an error if video codec is not supported", async () => {


### PR DESCRIPTION
## Summary
- allow constructing Mp4MuxerWrapper without audio tracks
- skip audio encoder setup in worker when audio params are invalid
- report `actualAudioCodec: null` when audio disabled
- handle disabled audio in mp4muxer and tests
- cover audio-disabled cases in tests

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
