### PR TITLE
Use logger.warn in encoder

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -64,7 +64,7 @@ export class Mp4Encoder {
 
     if (this.config.container === "webm") {
       // Early warning for unsupported container
-      console.warn(
+      logger.warn(
         "Mp4Encoder: WebM container output is not yet supported and will cause an error during initialization.",
       );
     }
@@ -119,7 +119,7 @@ export class Mp4Encoder {
     }
 
     if (this.worker) {
-      console.warn(
+      logger.warn(
         "Mp4Encoder already initialized or in progress. Call cancel() before re-initializing.",
       );
       // Allow re-initialization if already cancelled and cleaned up.
@@ -222,7 +222,7 @@ export class Mp4Encoder {
           !this.onDataCallback &&
           this.config.latencyMode === "realtime"
         ) {
-          console.warn(
+          logger.warn(
             "Mp4Encoder: Received dataChunk in real-time mode, but no onData callback was provided.",
           );
         }
@@ -279,7 +279,7 @@ export class Mp4Encoder {
       default:
         // Exhaustive check for MainThreadMessage types
         const _exhaustiveCheck: never = message;
-        console.warn(
+        logger.warn(
           "Mp4Encoder: Unknown message from worker:",
           _exhaustiveCheck,
         );
@@ -368,7 +368,7 @@ export class Mp4Encoder {
       this.config.channels <= 0 ||
       this.config.sampleRate <= 0
     ) {
-      console.warn(
+      logger.warn(
         "Audio encoding is disabled (audioBitrate, channels or sampleRate is zero/negative). Skipping addAudioBuffer.",
       );
       return Promise.resolve();
@@ -440,7 +440,7 @@ export class Mp4Encoder {
       this.config.channels <= 0 ||
       this.config.sampleRate <= 0
     ) {
-      console.warn(
+      logger.warn(
         "Audio encoding is disabled (audioBitrate, channels or sampleRate is zero/negative). Skipping addAudioData.",
       );
       return Promise.resolve();
@@ -515,7 +515,7 @@ export class Mp4Encoder {
       return Promise.reject(err);
     }
     if (this.onFinalizedPromise) {
-      console.warn("Finalize already called.");
+      logger.warn("Finalize already called.");
       const err = new Mp4EncoderError(
         EncoderErrorType.InternalError,
         "Finalize called multiple times.",

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { Mp4Encoder } from "../src/index"; // Assuming index.ts exports Mp4Encoder
 import { EncoderErrorType, Mp4EncoderError } from "../src/types"; // Import EncoderErrorType and Mp4EncoderError for error checking
 import { EncoderConfig } from "../src/types"; // Import EncoderConfig for type checking
+import { logger } from "../src/logger";
 
 // Mock the Worker class
 vi.mock("../src/worker", () => {
@@ -1117,7 +1118,7 @@ describe("Mp4Encoder", () => {
 
       mockWorkerInstance.postMessage.mockClear();
       const consoleWarnSpy = vi
-        .spyOn(console, "warn")
+        .spyOn(logger, "warn")
         .mockImplementation(() => {});
 
       try {
@@ -1144,7 +1145,7 @@ describe("Mp4Encoder", () => {
       mockWorkerInstance.postMessage.mockClear();
 
       const consoleWarnSpy = vi
-        .spyOn(console, "warn")
+        .spyOn(logger, "warn")
         .mockImplementation(() => {});
 
       const finalizePromise1 = encoder.finalize(); // 1回目 (まだ完了しない)
@@ -1442,7 +1443,7 @@ describe("Mp4Encoder", () => {
       await initPromise; // Now await the promise
       expect(mockWorkerInstance.onmessage).toBeTypeOf("function"); // Ensure onmessage is set
 
-      const warnSpy = vi.spyOn(console, "warn");
+      const warnSpy = vi.spyOn(logger, "warn");
       warnSpy.mockImplementation(() => {}); // Keep the mock simple
 
       await new Promise((resolve) => process.nextTick(resolve)); // Use process.nextTick


### PR DESCRIPTION
## Summary
- replace `console.warn` in `src/encoder.ts` with `logger.warn`
- update tests to spy on `logger.warn`

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`