### PR TITLE
Add frame dropping support

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ const result = await recorder.stopRecording();
   `EncoderConfig`:
     - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Setting `'webm'` will throw an error as WebM output is not yet supported.
     - `latencyMode?: 'quality' | 'realtime'`: (Optional) Encoding latency mode. `'quality'` (default) for best quality, `'realtime'` for lower latency and chunked output.
+    - `dropFrames?: boolean`: (Optional) Drop new video frames when the internal queue exceeds `maxQueueDepth`.
+    - `maxQueueDepth?: number`: (Optional) Maximum number of queued frames before dropping occurs. Defaults to unlimited.
     - `width: number`: Video width.
     - `height: number`: Video height.
     - `frameRate: number`: Video frame rate.

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,10 @@ export interface EncoderConfig {
     audio?: string;
   };
   latencyMode?: "quality" | "realtime"; // Default: 'quality'
+  /** Drop new video frames when the number of queued frames exceeds `maxQueueDepth`. */
+  dropFrames?: boolean;
+  /** Maximum number of queued video frames before dropping. Defaults to `Infinity`. */
+  maxQueueDepth?: number;
   /** Total frames for progress calculation if known in advance. */
   totalFrames?: number;
 }


### PR DESCRIPTION
## Summary
- allow dropping video frames when queue grows too large
- report progress for dropped frames
- document the new options
- test frame dropping behaviour

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`