### PR TITLE
Fix addCanvasFrame error handling

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -384,10 +384,6 @@ export class Mp4Encoder {
     });
     try {
       await this.addVideoFrame(frame);
-    } catch (e) {
-      // If posting the frame fails, manually close to avoid leaks.
-      await this.addVideoFrame(frame, timestamp);
-      throw e;
     } finally {
       frame.close();
     }


### PR DESCRIPTION
## Summary
- avoid calling `addVideoFrame` twice in `addCanvasFrame`
- test `addCanvasFrame` error propagation when `postMessage` throws

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`