### PR TITLE
Add test for AudioWorklet fallback

### DIFF
--- a/test/mediastream-recorder.test.ts
+++ b/test/mediastream-recorder.test.ts
@@ -202,6 +202,17 @@ describe("MediaStreamRecorder", () => {
     expect(encoderInstance.addAudioData).not.toHaveBeenCalled();
   });
 
+  it("rejects if AudioWorkletNode not available from encoder", async () => {
+    const recorder = new MediaStreamRecorder(config);
+    encoderInstance.getAudioWorkletNode.mockReturnValue(null);
+
+    await expect(
+      recorder.startRecording(mediaStream, { useAudioWorklet: true }),
+    ).rejects.toThrow(
+      "MediaStreamRecorder: AudioWorkletNode not available from encoder.",
+    );
+  });
+
   it("should throw if startRecording is called while already recording", async () => {
     const recorder = new MediaStreamRecorder(config);
     await recorder.startRecording(mediaStream);


### PR DESCRIPTION
## Summary
- add failing case when encoder doesn't provide an AudioWorkletNode

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
