### PR TITLE
Add hardware acceleration preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ async function encodeVideoToFile() {
     audioBitrate: 128_000,   // 128 kbps
     sampleRate: 48000,       // Recommended: 48000 for Opus
     channels: 2,
+    hardwareAcceleration: 'prefer-hardware', // Optional
   };
 
   const encoder = new Mp4Encoder(config);
@@ -134,6 +135,7 @@ async function encodeVideoRealtime() {
     audioBitrate: 128_000,
     sampleRate: 48000,
     channels: 2,
+    hardwareAcceleration: 'prefer-hardware',
   };
 
   let mediaSource;
@@ -284,6 +286,7 @@ const result = await recorder.stopRecording();
   `EncoderConfig`:
     - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Setting `'webm'` will throw an error as WebM output is not yet supported.
     - `latencyMode?: 'quality' | 'realtime'`: (Optional) Encoding latency mode. `'quality'` (default) for best quality, `'realtime'` for lower latency and chunked output.
+    - `hardwareAcceleration?: 'prefer-hardware' | 'prefer-software' | 'no-preference'`: (Optional) Hint to use hardware or software encoders when available.
     - `dropFrames?: boolean`: (Optional) Drop new video frames when the internal queue exceeds `maxQueueDepth`.
     - `maxQueueDepth?: number`: (Optional) Maximum number of queued frames before dropping occurs. Defaults to unlimited.
     - `width: number`: Video width.

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,11 @@ export interface EncoderConfig {
     audio?: string;
   };
   latencyMode?: "quality" | "realtime"; // Default: 'quality'
+  /** Preference for hardware or software encoding. */
+  hardwareAcceleration?:
+    | "prefer-hardware"
+    | "prefer-software"
+    | "no-preference";
   /** Drop new video frames when the number of queued frames exceeds `maxQueueDepth`. */
   dropFrames?: boolean;
   /** Maximum number of queued video frames before dropping. Defaults to `Infinity`. */

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -141,6 +141,9 @@ async function initializeEncoders(
     ...(currentConfig.latencyMode && {
       latencyMode: currentConfig.latencyMode,
     }),
+    ...(currentConfig.hardwareAcceleration && {
+      hardwareAcceleration: currentConfig.hardwareAcceleration,
+    }),
     ...(videoCodec === "vp9" && {
       scalabilityMode: "L1T2",
     }),
@@ -278,6 +281,9 @@ async function initializeEncoders(
       codec: resolvedAudioCodecString,
       ...(currentConfig.latencyMode && {
         latencyMode: currentConfig.latencyMode,
+      }),
+      ...(currentConfig.hardwareAcceleration && {
+        hardwareAcceleration: currentConfig.hardwareAcceleration,
       }),
       ...(currentConfig.audioEncoderConfig ?? {}),
     };


### PR DESCRIPTION
## Summary
- add hardwareAcceleration option to EncoderConfig
- forward hardwareAcceleration to VideoEncoder/AudioEncoder
- document hardwareAcceleration in README with examples

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
