### PR TITLE
Add audio bitrate mode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ const result = await recorder.stopRecording();
     - `frameRate: number`: Video frame rate.
     - `videoBitrate: number`: Video bitrate in bits per second.
     - `audioBitrate: number`: Audio bitrate in bits per second.
+    - `audioBitrateMode?: 'constant' | 'variable'`: (Optional) Set `'constant'` for CBR or `'variable'` for VBR when using AAC.
+      Chrome 119 or later has improved CBR support.
     - `sampleRate: number`: Audio sample rate (e.g., 44100, 48000). 48000 is recommended for Opus.
     - `channels: number`: Number of audio channels (e.g., 1 for mono, 2 for stereo).
     - `codec?: { video?: 'avc' | 'hevc' | 'vp9' | 'av1'; audio?: 'aac' | 'opus' }`: (Optional) Preferred codecs. Defaults to `{ video: 'avc', audio: 'aac' }`.
@@ -369,6 +371,13 @@ This library supports encoding to MP4 container format with the following codecs
 -   Codec support depends on the browser's WebCodecs implementation. The library attempts to use the specified codec and will fall back to a default (AVC for video, AAC for audio) if the preferred one is not supported, logging a warning. You can check `encoder.getActualVideoCodec()` and `encoder.getActualAudioCodec()` after `initialize()` to see what codecs are actually being used.
 -   When using `latencyMode: 'realtime'`, ensure the chosen codecs are suitable for streaming and are supported by your target MSE implementation (e.g., `MediaSource.isTypeSupported(...)`).
 -   For VP9 and Opus in MP4, browser support for playback can vary. Test thoroughly.
+
+## Choosing CBR or VBR for AAC
+
+Set `audioBitrateMode` in `EncoderConfig` to control how AAC bitrate is allocated.
+`'constant'` produces constant bitrate (CBR) output, while `'variable'` enables
+variable bitrate (VBR). Starting with Chrome 119, CBR handling in the
+`AudioEncoder` is much more reliable.
 
 ## Development
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ export interface EncoderConfig {
   frameRate: number;
   videoBitrate: number; // bps
   audioBitrate: number; // bps
+  /**
+   * Controls bitrate distribution for AAC. "constant" produces constant
+   * bitrate (CBR) output while "variable" enables variable bitrate (VBR).
+   * Not all browsers respect this setting. Chrome 119+ improves CBR support.
+   */
+  audioBitrateMode?: "constant" | "variable";
   sampleRate: number; // Hz
   channels: number; // e.g., 1 for mono, 2 for stereo
   container?: "mp4" | "webm"; // Default: 'mp4' or auto-selected based on codec

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -276,6 +276,9 @@ async function initializeEncoders(
       numberOfChannels: currentConfig.channels,
       bitrate: currentConfig.audioBitrate,
       codec: resolvedAudioCodecString,
+      ...(currentConfig.audioBitrateMode && {
+        bitrateMode: currentConfig.audioBitrateMode,
+      }),
       ...(currentConfig.latencyMode && {
         latencyMode: currentConfig.latencyMode,
       }),


### PR DESCRIPTION
## Summary
- allow choosing CBR or VBR with new `audioBitrateMode` option
- pass the mode through to the worker
- document AAC bitrate modes and mention Chrome 119 improvements

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
