### PR TITLE
Improve hardwareAcceleration fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ async function encodeVideoToFile() {
 encodeVideoToFile();
 ```
 
+### Hardware Acceleration Preference
+
+The `hardwareAcceleration` option hints whether to use hardware or software
+codecs when available. If the requested preference isn't supported, the encoder
+automatically falls back and logs a warning. Example:
+
+```typescript
+const config = {
+  width: 1920,
+  height: 1080,
+  frameRate: 30,
+  videoBitrate: 4_000_000,
+  audioBitrate: 192_000,
+  sampleRate: 48000,
+  channels: 2,
+  hardwareAcceleration: 'prefer-software',
+};
+```
+
+
 ## Generating Video from Images
 
 Decode a sequence of images with `ImageDecoder`, wrap each into a `VideoFrame`,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -60,6 +60,45 @@ function postMessageToMainThread(
   self.postMessage(message, transfer as any);
 }
 
+async function isConfigSupportedWithHwFallback(
+  Ctor: any,
+  config: any,
+  label: string,
+) {
+  let support = await Ctor.isConfigSupported(config as any);
+  if (support?.supported) return support.config;
+
+  const pref = config.hardwareAcceleration;
+  if (pref) {
+    let altPref: string | undefined;
+    if (pref === "prefer-hardware") altPref = "prefer-software";
+    else if (pref === "prefer-software") altPref = "prefer-hardware";
+
+    if (altPref) {
+      const opposite = { ...config, hardwareAcceleration: altPref };
+      support = await Ctor.isConfigSupported(opposite as any);
+      if (support?.supported) {
+        console.warn(
+          `Worker: ${label} hardwareAcceleration preference '${pref}' not supported. Using '${altPref}'.`,
+        );
+        return support.config;
+      }
+    }
+
+    const noPref = { ...config };
+    delete noPref.hardwareAcceleration;
+    support = await Ctor.isConfigSupported(noPref as any);
+    if (support?.supported) {
+      console.warn(
+        `Worker: ${label} hardwareAcceleration preference '${pref}' not supported. Using no preference.`,
+      );
+      return support.config;
+    }
+  }
+
+  return null;
+}
+
 function postQueueSize(): void {
   postMessageToMainThread({
     type: "queueSize",
@@ -174,11 +213,13 @@ async function initializeEncoders(
     return;
   }
 
-  let videoSupport = await VideoEncoderCtor.isConfigSupported(
-    baseVideoConfig as any,
+  let videoSupportConfig = await isConfigSupportedWithHwFallback(
+    VideoEncoderCtor,
+    baseVideoConfig,
+    "VideoEncoder",
   );
-  if (videoSupport?.supported) {
-    finalVideoEncoderConfig = videoSupport.config as VideoEncoderConfig;
+  if (videoSupportConfig) {
+    finalVideoEncoderConfig = videoSupportConfig as VideoEncoderConfig;
   } else if (
     videoCodec === "vp9" ||
     videoCodec === "av1" ||
@@ -200,11 +241,13 @@ async function initializeEncoders(
       avc: { format: "avcc" },
     };
     delete (fallbackVideoConfig as any).scalabilityMode;
-    videoSupport = await VideoEncoderCtor.isConfigSupported(
-      fallbackVideoConfig as any,
+    videoSupportConfig = await isConfigSupportedWithHwFallback(
+      VideoEncoderCtor,
+      fallbackVideoConfig,
+      "VideoEncoder",
     );
-    if (videoSupport?.supported) {
-      finalVideoEncoderConfig = videoSupport.config as VideoEncoderConfig;
+    if (videoSupportConfig) {
+      finalVideoEncoderConfig = videoSupportConfig as VideoEncoderConfig;
     } else {
       postMessageToMainThread({
         type: "error",
@@ -312,11 +355,13 @@ async function initializeEncoders(
       return;
     }
 
-    let audioSupport = await AudioEncoderCtor.isConfigSupported(
-      baseAudioConfig as any,
+    let audioSupportConfig = await isConfigSupportedWithHwFallback(
+      AudioEncoderCtor,
+      baseAudioConfig,
+      "AudioEncoder",
     );
-    if (audioSupport?.supported) {
-      finalAudioEncoderConfig = audioSupport.config as AudioEncoderConfig;
+    if (audioSupportConfig) {
+      finalAudioEncoderConfig = audioSupportConfig as AudioEncoderConfig;
     } else if (audioCodec === "opus") {
       console.warn(
         `Worker: Audio codec ${audioCodec} not supported or config invalid. Falling back to AAC.`,
@@ -326,11 +371,13 @@ async function initializeEncoders(
         ...baseAudioConfig,
         codec: currentConfig.codecString?.audio ?? "mp4a.40.2",
       };
-      audioSupport = await AudioEncoderCtor.isConfigSupported(
-        fallbackAudioConfig as any,
+      audioSupportConfig = await isConfigSupportedWithHwFallback(
+        AudioEncoderCtor,
+        fallbackAudioConfig,
+        "AudioEncoder",
       );
-      if (audioSupport?.supported) {
-        finalAudioEncoderConfig = audioSupport.config as AudioEncoderConfig;
+      if (audioSupportConfig) {
+        finalAudioEncoderConfig = audioSupportConfig as AudioEncoderConfig;
       } else {
         postMessageToMainThread({
           type: "error",


### PR DESCRIPTION
## Summary
- add helper to retry `isConfigSupported` with different `hardwareAcceleration`
- fall back when VideoEncoder/AudioEncoder configs are unsupported
- document hardware acceleration preference in README

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
