### PR TITLE
Add WebM container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebCodecs MP4/WebM Encoder (MP4 Muxer Currently)
 
-A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) using the WebCodecs API and mux them into an MP4 container. **WebM output is not yet supported.**
+A TypeScript library to encode video (H.264/AVC, VP9, VP8) and audio (AAC, Opus) using the WebCodecs API and mux them into MP4 or WebM containers.
 
 ## Features
 
@@ -14,7 +14,7 @@ A TypeScript library to encode video (H.264/AVC, VP9) and audio (AAC, Opus) usin
 - Built with TypeScript, providing type definitions.
 - Automatic codec fallback (e.g., VP9 to AVC, Opus to AAC) if the preferred codec is not supported.
 - Queue management with `dropFrames` and `maxQueueDepth` to control encoder backlog.
-- **WebM Container Support**: WebM output is **not yet implemented.** Setting `container: 'webm'` will throw an error during initialization.
+- **WebM Container Support**: Set `container: 'webm'` to output a WebM file using the `webm-muxer` library.
 
 ## Installation
 
@@ -199,7 +199,7 @@ async function encodeVideoRealtime() {
       console.log("MediaSource opened");
 
       await encoder.initialize({
-        onData: (chunk, isHeader) => {
+        onData: (chunk, isHeader, container) => {
           if (
             sourceBuffer &&
             !sourceBuffer.updating &&
@@ -357,7 +357,7 @@ const result = await recorder.stopRecording();
 - **`new Mp4Encoder(config: EncoderConfig)`**
   Creates a new encoder instance.
   `EncoderConfig`:
-    - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Setting `'webm'` will throw an error as WebM output is not yet supported.
+    - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Use `'webm'` for WebM output.
     - `latencyMode?: 'quality' | 'realtime'`: (Optional) Encoding latency mode. `'quality'` (default) for best quality, `'realtime'` for lower latency and chunked output.
     - `dropFrames?: boolean`: (Optional) Drop new video frames when the worker-reported video queue size exceeds `maxQueueDepth`.
     - `maxQueueDepth?: number`: (Optional) Maximum video queue size before dropping occurs. The queue size uses WebCodecs `encodeQueueSize`. Defaults to unlimited.
@@ -387,7 +387,7 @@ const result = await recorder.stopRecording();
   - `onProgress?: (processedFrames: number, totalFrames?: number) => void`: Callback for encoding progress. `totalFrames` might be undefined in real-time or if not provided.
   - `totalFrames?: number`: Total number of video frames to be encoded. Used for progress calculation.
   - `onError?: (error: Mp4EncoderError) => void`: Callback for errors occurring in the worker after initialization. Receives an `Mp4EncoderError` object.
-  - `onData?: (chunk: Uint8Array, isHeader?: boolean) => void`: Callback for receiving muxed data chunks. Used when `latencyMode` is `'realtime'`. `isHeader` is true for the initial MP4 header chunk.
+  - `onData?: (chunk: Uint8Array, isHeader?: boolean, container?: 'mp4' | 'webm') => void`: Callback for receiving muxed data chunks. Used when `latencyMode` is `'realtime'`. `isHeader` is true for the initial container header.
   - `worker?: Worker`: Provide a pre-created `Worker` instance instead of letting `Mp4Encoder` create one.
   - `workerScriptUrl?: string | URL`: Specify a custom worker script to load when creating the worker.
   - `useAudioWorklet?: boolean`: Use an `AudioWorklet` to pipe audio data directly to the worker for lower latency.

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -7,7 +7,7 @@ export type RealtimeDataCallback = (
   chunk: Uint8Array,
   offset?: number,
   isHeader?: boolean,
-  // container?: 'mp4' | 'webm' // Provided via worker messages when streaming
+  container?: "mp4" | "webm",
 ) => void;
 
 export interface Mp4EncoderInitializeOptions {
@@ -68,13 +68,6 @@ export class Mp4Encoder {
       },
     };
 
-    if (this.config.container === "webm") {
-      // Early warning for unsupported container
-      logger.warn(
-        "Mp4Encoder: WebM container output is not yet supported and will cause an error during initialization.",
-      );
-    }
-
     // Initialize worker later, only if supported and initialize() is called.
     // This avoids creating a worker if the class is just instantiated.
   }
@@ -104,15 +97,6 @@ export class Mp4Encoder {
       // and this.onErrorCallback will be called by the caller if they wish.
       // this.handleError(err);
       throw err; // Throw immediately
-    }
-
-    if (this.config.container === "webm") {
-      const err = new Mp4EncoderError(
-        EncoderErrorType.NotSupported,
-        "WebM container output is not yet supported.",
-      );
-      this.handleError(err);
-      throw err;
     }
 
     if (!Mp4Encoder.isSupported()) {
@@ -227,9 +211,8 @@ export class Mp4Encoder {
         break;
       case "dataChunk": // Handle real-time data chunks
         if (this.config.latencyMode === "realtime" && this.onDataCallback) {
-          const { chunk, isHeader } = message;
-          // Pass only chunk and isHeader as offset is not reliably used/provided yet
-          this.onDataCallback(chunk, undefined, isHeader);
+          const { chunk, isHeader, container } = message;
+          this.onDataCallback(chunk, undefined, isHeader, container);
         } else if (
           this.onDataCallback &&
           this.config.latencyMode !== "realtime"

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,9 +12,9 @@ export interface EncoderConfig {
   audioBitrateMode?: "constant" | "variable";
   sampleRate: number; // Hz
   channels: number; // e.g., 1 for mono, 2 for stereo
-  container?: "mp4" | "webm"; // Default: 'mp4' or auto-selected based on codec
+  container?: "mp4" | "webm"; // Default: 'mp4'. Set 'webm' for WebM output.
   codec?: {
-    video?: "avc" | "hevc" | "vp9" | "av1"; // Default: 'avc' (H.264)
+    video?: "avc" | "hevc" | "vp9" | "vp8" | "av1"; // Default: 'avc' (H.264)
     audio?: "aac" | "opus"; // Default: 'aac'
   };
   /**

--- a/src/webmmuxer.ts
+++ b/src/webmmuxer.ts
@@ -1,0 +1,186 @@
+import WebMMuxer from "webm-muxer";
+import type {
+  EncoderConfig,
+  MainThreadMessage,
+  WorkerDataChunkMessage,
+} from "./types";
+import { EncoderErrorType } from "./types";
+
+class CallbackWritableStream {
+  private position = 0;
+  constructor(private onData: (chunk: Uint8Array, position: number) => void) {}
+
+  write({ data, position }: { data: Uint8Array; position: number }): void {
+    this.onData(data, position);
+    this.position = position + data.byteLength;
+  }
+}
+
+export class WebMMuxerWrapper {
+  private muxer: WebMMuxer;
+  private videoConfigured = false;
+  private audioConfigured = false;
+  private postMessageToMain: (
+    message: MainThreadMessage,
+    transfer?: Transferable[],
+  ) => void;
+  private config: EncoderConfig;
+
+  constructor(
+    config: EncoderConfig,
+    postMessageCallback: (
+      message: MainThreadMessage,
+      transfer?: Transferable[],
+    ) => void,
+    options?: { disableAudio?: boolean },
+  ) {
+    this.config = config;
+    this.postMessageToMain = postMessageCallback;
+    const disableAudio = options?.disableAudio ?? false;
+
+    const videoCodecOption = config.codec?.video ?? "vp9";
+    let muxerVideoCodec: string;
+    switch (videoCodecOption) {
+      case "vp8":
+        muxerVideoCodec = "V_VP8";
+        break;
+      case "vp9":
+        muxerVideoCodec = "V_VP9";
+        break;
+      case "av1":
+        muxerVideoCodec = "V_AV1";
+        break;
+      default:
+        muxerVideoCodec = "V_VP9";
+        break;
+    }
+
+    const muxerAudioCodec = "A_OPUS"; // only opus supported
+
+    const target =
+      config.latencyMode === "realtime"
+        ? new CallbackWritableStream((chunk, position) => {
+            const chunkCopy = new Uint8Array(chunk.slice(0));
+            const isHeader = position === 0;
+            const message: WorkerDataChunkMessage = {
+              type: "dataChunk",
+              chunk: chunkCopy,
+              offset: position,
+              isHeader,
+              container: "webm",
+            };
+            this.postMessageToMain(message, [chunkCopy.buffer]);
+          })
+        : ("buffer" as const);
+
+    const optionsForMuxer: any = {
+      target,
+      video: {
+        codec: muxerVideoCodec,
+        width: config.width,
+        height: config.height,
+        frameRate: config.frameRate,
+      },
+    };
+
+    if (!disableAudio) {
+      optionsForMuxer.audio = {
+        codec: muxerAudioCodec,
+        numberOfChannels: config.channels,
+        sampleRate: config.sampleRate,
+      };
+    }
+
+    this.muxer = new WebMMuxer(optionsForMuxer);
+    this.videoConfigured = true;
+    this.audioConfigured = !disableAudio;
+  }
+
+  addVideoChunk(
+    chunk: EncodedVideoChunk,
+    meta?: EncodedVideoChunkMetadata,
+  ): void {
+    if (!this.videoConfigured) {
+      this.postMessageToMain({
+        type: "error",
+        errorDetail: {
+          message: "WebM: Video track not configured.",
+          type: EncoderErrorType.ConfigurationError,
+        },
+      });
+      return;
+    }
+    try {
+      this.muxer.addVideoChunk(chunk, meta as any);
+    } catch (e: any) {
+      this.postMessageToMain({
+        type: "error",
+        errorDetail: {
+          message: `WebM: Error adding video chunk: ${e.message}`,
+          type: EncoderErrorType.MuxingFailed,
+          stack: e.stack,
+        },
+      });
+    }
+  }
+
+  addAudioChunk(
+    chunk: EncodedAudioChunk,
+    meta?: EncodedAudioChunkMetadata,
+  ): void {
+    if (!this.audioConfigured) return;
+    try {
+      this.muxer.addAudioChunk(chunk, meta as any);
+    } catch (e: any) {
+      this.postMessageToMain({
+        type: "error",
+        errorDetail: {
+          message: `WebM: Error adding audio chunk: ${e.message}`,
+          type: EncoderErrorType.MuxingFailed,
+          stack: e.stack,
+        },
+      });
+    }
+  }
+
+  finalize(): Uint8Array | null {
+    if (this.config.latencyMode === "realtime") {
+      try {
+        this.muxer.finalize();
+      } catch (e: any) {
+        this.postMessageToMain({
+          type: "error",
+          errorDetail: {
+            message: `WebM: Error finalizing muxer (realtime): ${e.message}`,
+            type: EncoderErrorType.MuxingFailed,
+            stack: e.stack,
+          },
+        });
+      }
+      return null;
+    }
+
+    try {
+      const buffer = this.muxer.finalize();
+      if (buffer) return new Uint8Array(buffer);
+      this.postMessageToMain({
+        type: "error",
+        errorDetail: {
+          message: "WebM: Muxer finalized without output in non-realtime mode.",
+          type: EncoderErrorType.MuxingFailed,
+        },
+      });
+      return null;
+    } catch (e: any) {
+      this.postMessageToMain({
+        type: "error",
+        errorDetail: {
+          message: `WebM: Error finalizing muxer (non-realtime): ${e.message}`,
+          type: EncoderErrorType.MuxingFailed,
+          stack: e.stack,
+        },
+      });
+      return null;
+    }
+  }
+}

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,4 +1,5 @@
 import { Mp4MuxerWrapper } from "./mp4muxer";
+import { WebMMuxerWrapper } from "./webmmuxer";
 import type {
   EncoderConfig,
   WorkerMessage,
@@ -14,7 +15,7 @@ import logger from "./logger";
 
 let videoEncoder: VideoEncoder | null = null;
 let audioEncoder: AudioEncoder | null = null;
-let muxer: Mp4MuxerWrapper | null = null;
+let muxer: Mp4MuxerWrapper | WebMMuxerWrapper | null = null;
 let currentConfig: EncoderConfig | null = null;
 let totalFramesToProcess: number | undefined;
 let processedFrames: number = 0;
@@ -88,31 +89,22 @@ async function initializeEncoders(
     return;
   }
 
-  if (currentConfig.container === "webm") {
-    postMessageToMainThread({
-      type: "error",
-      errorDetail: {
-        message: "Worker: WebM container is not supported in this version.",
-        type: EncoderErrorType.NotSupported,
-      },
-    });
-    return;
-  }
-
   const audioDisabled =
     currentConfig.audioBitrate <= 0 ||
     currentConfig.channels <= 0 ||
     currentConfig.sampleRate <= 0;
 
   try {
-    muxer = new Mp4MuxerWrapper(currentConfig, postMessageToMainThread, {
+    const MuxerCtor =
+      currentConfig.container === "webm" ? WebMMuxerWrapper : Mp4MuxerWrapper;
+    muxer = new MuxerCtor(currentConfig, postMessageToMainThread, {
       disableAudio: audioDisabled,
     });
   } catch (e: any) {
     postMessageToMainThread({
       type: "error",
       errorDetail: {
-        message: `Worker: Failed to initialize MP4 Muxer: ${e.message}`,
+        message: `Worker: Failed to initialize Muxer: ${e.message}`,
         type: EncoderErrorType.InitializationFailed,
         stack: e.stack,
       },
@@ -121,7 +113,18 @@ async function initializeEncoders(
     return;
   }
 
-  let videoCodec = currentConfig.codec?.video ?? "avc";
+  let videoCodec =
+    currentConfig.codec?.video ??
+    (currentConfig.container === "webm" ? "vp9" : "avc");
+  if (
+    currentConfig.container === "webm" &&
+    (videoCodec === "avc" || videoCodec === "hevc")
+  ) {
+    console.warn(
+      `Worker: Video codec ${videoCodec} not compatible with WebM. Switching to VP9.`,
+    );
+    videoCodec = "vp9";
+  }
   let finalVideoEncoderConfig: VideoEncoderConfig | null = null;
 
   const resolvedVideoCodecString =
@@ -134,11 +137,13 @@ async function initializeEncoders(
         )
       : videoCodec === "vp9"
         ? "vp09.00.50.08"
-        : videoCodec === "hevc"
-          ? "hvc1"
-          : videoCodec === "av1"
-            ? "av01"
-            : "");
+        : videoCodec === "vp8"
+          ? "vp8"
+          : videoCodec === "hevc"
+            ? "hvc1"
+            : videoCodec === "av1"
+              ? "av01"
+              : "");
 
   const baseVideoConfig = {
     width: currentConfig.width,
@@ -200,6 +205,17 @@ async function initializeEncoders(
       avc: { format: "avcc" },
     };
     delete (fallbackVideoConfig as any).scalabilityMode;
+    if (currentConfig.container === "webm") {
+      postMessageToMainThread({
+        type: "error",
+        errorDetail: {
+          message: "Worker: VP9/VP8/AV1 not supported for WebM container.",
+          type: EncoderErrorType.NotSupported,
+        },
+      });
+      cleanup();
+      return;
+    }
     videoSupport = await VideoEncoderCtor.isConfigSupported(
       fallbackVideoConfig as any,
     );
@@ -275,7 +291,15 @@ async function initializeEncoders(
   }
 
   let finalAudioEncoderConfig: AudioEncoderConfig | null = null;
-  let audioCodec = currentConfig.codec?.audio ?? "aac";
+  let audioCodec =
+    currentConfig.codec?.audio ??
+    (currentConfig.container === "webm" ? "opus" : "aac");
+  if (currentConfig.container === "webm" && audioCodec === "aac") {
+    console.warn(
+      "Worker: AAC audio codec is not compatible with WebM. Switching to Opus.",
+    );
+    audioCodec = "opus";
+  }
 
   if (!audioDisabled) {
     const resolvedAudioCodecString =
@@ -321,6 +345,18 @@ async function initializeEncoders(
       console.warn(
         `Worker: Audio codec ${audioCodec} not supported or config invalid. Falling back to AAC.`,
       );
+      if (currentConfig.container === "webm") {
+        postMessageToMainThread({
+          type: "error",
+          errorDetail: {
+            message:
+              "Worker: Opus audio codec not supported for WebM container.",
+            type: EncoderErrorType.NotSupported,
+          },
+        });
+        cleanup();
+        return;
+      }
       audioCodec = "aac";
       const fallbackAudioConfig = {
         ...baseAudioConfig,

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -1285,7 +1285,12 @@ describe("Mp4Encoder", () => {
           },
         });
       }
-      expect(onDataCallback).toHaveBeenCalledWith(headerChunk, undefined, true);
+      expect(onDataCallback).toHaveBeenCalledWith(
+        headerChunk,
+        undefined,
+        true,
+        "mp4",
+      );
 
       // Simulate worker sending a media data chunk
       const mediaChunk = new Uint8Array([5, 6, 7, 8]);
@@ -1299,7 +1304,12 @@ describe("Mp4Encoder", () => {
           },
         });
       }
-      expect(onDataCallback).toHaveBeenCalledWith(mediaChunk, undefined, false);
+      expect(onDataCallback).toHaveBeenCalledWith(
+        mediaChunk,
+        undefined,
+        false,
+        "mp4",
+      );
       expect(onDataCallback).toHaveBeenCalledTimes(2);
     });
 

--- a/test/helpers/worker-test-utils.ts
+++ b/test/helpers/worker-test-utils.ts
@@ -9,6 +9,9 @@ export const mockMuxerInstanceForWorker = {
 vi.mock("../../src/mp4muxer", () => ({
   Mp4MuxerWrapper: vi.fn(() => mockMuxerInstanceForWorker),
 }));
+vi.mock("../../src/webmmuxer", () => ({
+  WebMMuxerWrapper: vi.fn(() => mockMuxerInstanceForWorker),
+}));
 
 export const mockSelf = {
   postMessage: vi.fn(),

--- a/test/webmmuxer.test.ts
+++ b/test/webmmuxer.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WebMMuxerWrapper } from "../src/webmmuxer";
+import type { EncoderConfig } from "../src/types";
+
+vi.mock("webm-muxer", () => {
+  const mockMuxerMethods = {
+    addVideoChunk: vi.fn(),
+    addAudioChunk: vi.fn(),
+    finalize: vi.fn(),
+  };
+  class DummyTarget {
+    write(_data: any) {}
+  }
+  const WebMMuxerMock = vi.fn(() => mockMuxerMethods);
+  return {
+    default: WebMMuxerMock,
+    _mockMuxerMethods: mockMuxerMethods,
+    _DummyTarget: DummyTarget,
+  };
+});
+
+interface MockedModule {
+  default: any;
+  _mockMuxerMethods: {
+    addVideoChunk: any;
+    addAudioChunk: any;
+    finalize: any;
+  };
+  _DummyTarget: any;
+}
+
+const baseConfig: EncoderConfig = {
+  width: 320,
+  height: 240,
+  frameRate: 30,
+  videoBitrate: 1000,
+  audioBitrate: 64,
+  sampleRate: 48000,
+  channels: 2,
+  container: "webm",
+  codec: { video: "vp9", audio: "opus" },
+};
+
+describe("WebMMuxerWrapper", () => {
+  let mockMuxerMethods: MockedModule["_mockMuxerMethods"];
+  let postMessageCallback: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    const module = (await import("webm-muxer")) as unknown as MockedModule;
+    mockMuxerMethods = module._mockMuxerMethods;
+    vi.clearAllMocks();
+    postMessageCallback = vi.fn();
+  });
+
+  it("adds video and audio chunks", () => {
+    const wrapper = new WebMMuxerWrapper(baseConfig, postMessageCallback);
+    wrapper.addVideoChunk({} as any, {} as any);
+    wrapper.addAudioChunk({} as any, {} as any);
+    expect(mockMuxerMethods.addVideoChunk).toHaveBeenCalled();
+    expect(mockMuxerMethods.addAudioChunk).toHaveBeenCalled();
+  });
+
+  it("finalizes and returns Uint8Array in non-realtime mode", () => {
+    const expected = new Uint8Array([1, 2, 3]);
+    mockMuxerMethods.finalize.mockReturnValueOnce(expected.buffer);
+    const wrapper = new WebMMuxerWrapper(baseConfig, postMessageCallback);
+    const out = wrapper.finalize();
+    expect(mockMuxerMethods.finalize).toHaveBeenCalled();
+    expect(out).toEqual(expected);
+  });
+
+  it("streams chunks in realtime", async () => {
+    const module = (await import("webm-muxer")) as unknown as MockedModule;
+    const realtimeConfig = { ...baseConfig, latencyMode: "realtime" as const };
+    const wrapper = new WebMMuxerWrapper(realtimeConfig, postMessageCallback);
+    const DummyTarget = module._DummyTarget;
+    // simulate write callback
+    const dataCb = (DummyTarget as any).mock?.calls?.[0]?.[0]?.onData;
+    if (dataCb) {
+      const chunk = new Uint8Array([1]);
+      dataCb(chunk, 0);
+      expect(postMessageCallback).toHaveBeenCalledWith(
+        expect.objectContaining({ container: "webm", isHeader: true }),
+        [chunk.buffer],
+      );
+    }
+  });
+});

--- a/test/worker-finalize.test.ts
+++ b/test/worker-finalize.test.ts
@@ -137,7 +137,7 @@ describe("handleFinalize", () => {
       expect.objectContaining({
         type: "error",
         errorDetail: expect.objectContaining({
-          message: `Worker: Failed to initialize MP4 Muxer: ${muxerConstructionError.message}`,
+          message: `Worker: Failed to initialize Muxer: ${muxerConstructionError.message}`,
           type: "initialization-failed",
         }),
       }),


### PR DESCRIPTION
## Summary
- implement WebMMuxerWrapper using `webm-muxer`
- allow choosing WebM container via encoder config
- add codec compatibility checks in worker
- stream WebM clusters when in realtime mode
- update documentation for WebM usage
- add unit tests for WebM muxer and worker

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`