### PR TITLE
Rename Mp4Encoder to WebCodecsEncoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Running `npm install` will automatically run the `postinstall` script, applying 
 You can find this example in [`examples/encode-to-file.ts`](examples/encode-to-file.ts) for a quick way to try it out.
 
 ```typescript
-import { Mp4Encoder } from "webcodecs-muxer";
+import { WebCodecsEncoder } from "webcodecs-muxer";
 
 async function encodeVideoToFile() {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error("WebCodecs or Workers not supported.");
     return;
   }
@@ -50,7 +50,7 @@ async function encodeVideoToFile() {
     hardwareAcceleration: 'prefer-hardware', // Optional
   };
 
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
 
   try {
     await encoder.initialize({
@@ -131,21 +131,21 @@ const config = {
 ## Generating Video from Images
 
 Decode a sequence of images with `ImageDecoder`, wrap each into a `VideoFrame`,
-and feed them to `Mp4Encoder`. See
+and feed them to `WebCodecsEncoder`. See
 [`examples/image-sequence.ts`](examples/image-sequence.ts) for a runnable
 example.
 
 ```typescript
-import { Mp4Encoder } from "webcodecs-muxer";
+import { WebCodecsEncoder } from "webcodecs-muxer";
 
 async function encodeImageSequence(imageUrls: string[]) {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error("WebCodecs or Workers not supported.");
     return;
   }
 
   const config = { width: 1280, height: 720, frameRate: 30 };
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
   await encoder.initialize({ totalFrames: imageUrls.length });
 
   for (const [index, url] of imageUrls.entries()) {
@@ -175,10 +175,10 @@ For applications like live streaming, you can configure the encoder to output da
 See [`examples/encode-realtime.ts`](examples/encode-realtime.ts) for the full runnable snippet.
 
 ```typescript
-import { Mp4Encoder } from "webcodecs-muxer";
+import { WebCodecsEncoder } from "webcodecs-muxer";
 
 async function encodeVideoRealtime() {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error("WebCodecs or Workers not supported.");
     return;
   }
@@ -285,7 +285,7 @@ async function encodeVideoRealtime() {
     return;
   }
 
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
 
   async function startEncoding() {
     console.log("Starting encoding process...");
@@ -358,7 +358,7 @@ async function encodeVideoRealtime() {
 
 `MediaStreamRecorder` simplifies capturing from a `MediaStream`. It internally
 uses `MediaStreamTrackProcessor` to feed `VideoFrame` and `AudioData` to
-`Mp4Encoder`.
+`WebCodecsEncoder`.
 The snippet below is available in [`examples/record-mediastream.ts`](examples/record-mediastream.ts).
 
 ```typescript
@@ -371,10 +371,10 @@ const result = await recorder.stopRecording();
 
 ## API
 
-- **`Mp4Encoder.isSupported(): boolean`**
+- **`WebCodecsEncoder.isSupported(): boolean`**
   Checks if `VideoEncoder`, `AudioEncoder`, and `Worker` are available in the current environment.
 
-- **`new Mp4Encoder(config: EncoderConfig)`**
+- **`new WebCodecsEncoder(config: EncoderConfig)`**
   Creates a new encoder instance.
   `EncoderConfig`:
     - `container?: 'mp4' | 'webm'`: (Optional) Container format. Defaults to `'mp4'`. Use `'webm'` for WebM output.
@@ -400,15 +400,15 @@ const result = await recorder.stopRecording();
     - `videoEncoderConfig?: Partial<VideoEncoderConfig>`: (Optional) Additional codec-specific options passed to `VideoEncoder.configure`. Include `hardwareAcceleration` to prefer hardware or software encoding.
     - `audioEncoderConfig?: Partial<AudioEncoderConfig>`: (Optional) Additional settings passed to `AudioEncoder.configure`. This also accepts `hardwareAcceleration`.
 
-- **`encoder.initialize(options?: Mp4EncoderInitializeOptions): Promise<void>`**
+- **`encoder.initialize(options?: WebCodecsEncoderInitializeOptions): Promise<void>`**
   Initializes the encoder and worker.
-  `Mp4EncoderInitializeOptions`:
+  `WebCodecsEncoderInitializeOptions`:
 
   - `onProgress?: (processedFrames: number, totalFrames?: number) => void`: Callback for encoding progress. `totalFrames` might be undefined in real-time or if not provided.
   - `totalFrames?: number`: Total number of video frames to be encoded. Used for progress calculation.
-  - `onError?: (error: Mp4EncoderError) => void`: Callback for errors occurring in the worker after initialization. Receives an `Mp4EncoderError` object.
+  - `onError?: (error: WebCodecsEncoderError) => void`: Callback for errors occurring in the worker after initialization. Receives an `WebCodecsEncoderError` object.
   - `onData?: (chunk: Uint8Array, isHeader?: boolean, container?: 'mp4' | 'webm') => void`: Callback for receiving muxed data chunks. Used when `latencyMode` is `'realtime'`. `isHeader` is true for the initial container header.
-  - `worker?: Worker`: Provide a pre-created `Worker` instance instead of letting `Mp4Encoder` create one.
+  - `worker?: Worker`: Provide a pre-created `Worker` instance instead of letting `WebCodecsEncoder` create one.
   - `workerScriptUrl?: string | URL`: Specify a custom worker script to load when creating the worker.
   - `useAudioWorklet?: boolean`: Use an `AudioWorklet` to pipe audio data directly to the worker for lower latency.
 
@@ -451,12 +451,12 @@ const result = await recorder.stopRecording();
   Returns the current audio encoder queue size reported by the worker.
 
 - **`MediaStreamRecorder.isSupported(): boolean`**
-  Checks if `MediaStreamTrackProcessor` and `Mp4Encoder` are available.
+  Checks if `MediaStreamTrackProcessor` and `WebCodecsEncoder` are available.
 
 - **`new MediaStreamRecorder(config: EncoderConfig)`**
-  Creates a recorder that internally uses `Mp4Encoder`.
+  Creates a recorder that internally uses `WebCodecsEncoder`.
 
-- **`recorder.startRecording(stream: MediaStream, options?: Mp4EncoderInitializeOptions): Promise<void>`**
+- **`recorder.startRecording(stream: MediaStream, options?: WebCodecsEncoderInitializeOptions): Promise<void>`**
   Starts reading `VideoFrame` and `AudioData` from the provided stream.
 
 - **`recorder.stopRecording(): Promise<Uint8Array>`**

--- a/examples/encode-realtime.ts
+++ b/examples/encode-realtime.ts
@@ -1,7 +1,7 @@
-import { Mp4Encoder } from 'webcodecs-muxer';
+import { WebCodecsEncoder } from 'webcodecs-muxer';
 
 async function encodeVideoRealtime() {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error('WebCodecs or Workers not supported.');
     return;
   }
@@ -84,7 +84,7 @@ async function encodeVideoRealtime() {
     return;
   }
 
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
 
   async function startEncoding() {
     console.log("Starting encoding process...");

--- a/examples/encode-to-file.ts
+++ b/examples/encode-to-file.ts
@@ -1,7 +1,7 @@
-import { Mp4Encoder } from 'webcodecs-muxer';
+import { WebCodecsEncoder } from 'webcodecs-muxer';
 
 async function encodeVideoToFile() {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error('WebCodecs or Workers not supported.');
     return;
   }
@@ -16,7 +16,7 @@ async function encodeVideoToFile() {
     channels: 2,
   };
 
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
 
   try {
     await encoder.initialize({

--- a/examples/image-sequence.ts
+++ b/examples/image-sequence.ts
@@ -1,7 +1,7 @@
-import { Mp4Encoder } from "webcodecs-muxer";
+import { WebCodecsEncoder } from "webcodecs-muxer";
 
 export async function encodeImageSequence(imageUrls: string[]) {
-  if (!Mp4Encoder.isSupported()) {
+  if (!WebCodecsEncoder.isSupported()) {
     console.error("WebCodecs or Workers not supported.");
     return;
   }
@@ -13,7 +13,7 @@ export async function encodeImageSequence(imageUrls: string[]) {
     videoBitrate: 2_000_000,
   };
 
-  const encoder = new Mp4Encoder(config);
+  const encoder = new WebCodecsEncoder(config);
   await encoder.initialize({ totalFrames: imageUrls.length });
 
   for (const [index, url] of imageUrls.entries()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-export { Mp4Encoder } from "./encoder";
+export { WebCodecsEncoder } from "./encoder";
 export { MediaStreamRecorder } from "./mediastream-recorder";
 export type {
   EncoderConfig,
   ProgressCallback,
-  Mp4EncoderError,
+  WebCodecsEncoderError,
   EncoderErrorType,
 } from "./types";

--- a/src/mediastream-recorder.ts
+++ b/src/mediastream-recorder.ts
@@ -1,8 +1,8 @@
-import { Mp4Encoder, Mp4EncoderInitializeOptions } from "./encoder";
+import { WebCodecsEncoder, WebCodecsEncoderInitializeOptions } from "./encoder";
 import type { EncoderConfig } from "./types";
 
 export class MediaStreamRecorder {
-  private encoder: Mp4Encoder;
+  private encoder: WebCodecsEncoder;
   private videoReader?: ReadableStreamDefaultReader<VideoFrame>;
   private audioReader?: ReadableStreamDefaultReader<AudioData>;
   private videoTrack?: MediaStreamTrack;
@@ -12,19 +12,19 @@ export class MediaStreamRecorder {
   private onErrorCallback?: (error: any) => void;
 
   constructor(private config: EncoderConfig) {
-    this.encoder = new Mp4Encoder(config);
+    this.encoder = new WebCodecsEncoder(config);
   }
 
   static isSupported(): boolean {
     return (
       typeof MediaStreamTrackProcessor !== "undefined" &&
-      Mp4Encoder.isSupported()
+      WebCodecsEncoder.isSupported()
     );
   }
 
   async startRecording(
     stream: MediaStream,
-    options?: Mp4EncoderInitializeOptions,
+    options?: WebCodecsEncoderInitializeOptions,
   ): Promise<void> {
     if (this.recording) {
       throw new Error("MediaStreamRecorder: already recording.");

--- a/src/types.ts
+++ b/src/types.ts
@@ -65,16 +65,16 @@ export enum EncoderErrorType {
   WorkerError = "worker-error",
 }
 
-export class Mp4EncoderError extends Error {
+export class WebCodecsEncoderError extends Error {
   constructor(
     public type: EncoderErrorType,
     message: string,
     public cause?: unknown,
   ) {
     super(message);
-    this.name = "Mp4EncoderError";
+    this.name = "WebCodecsEncoderError";
     // Ensure the prototype chain is correct for custom errors
-    Object.setPrototypeOf(this, Mp4EncoderError.prototype);
+    Object.setPrototypeOf(this, WebCodecsEncoderError.prototype);
   }
 }
 

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import { Mp4Encoder } from "../src/index"; // Assuming index.ts exports Mp4Encoder
-import { EncoderErrorType, Mp4EncoderError } from "../src/types"; // Import EncoderErrorType and Mp4EncoderError for error checking
+import { WebCodecsEncoder } from "../src/index"; // Assuming index.ts exports WebCodecsEncoder
+import { EncoderErrorType, WebCodecsEncoderError } from "../src/types"; // Import EncoderErrorType and WebCodecsEncoderError for error checking
 import { EncoderConfig } from "../src/types"; // Import EncoderConfig for type checking
 import { logger } from "../src/logger";
 
@@ -44,7 +44,7 @@ function createMockAudioBuffer(
   } as unknown as AudioBuffer;
 }
 
-describe("Mp4Encoder", () => {
+describe("WebCodecsEncoder", () => {
   let mockWorkerInstance: any;
 
   beforeEach(() => {
@@ -53,8 +53,8 @@ describe("Mp4Encoder", () => {
     mockWorkerInstance = {
       postMessage: vi.fn(),
       terminate: vi.fn(),
-      onmessage: null, // Will be set by Mp4Encoder during initialize
-      onerror: null, // Will be set by Mp4Encoder during initialize
+      onmessage: null, // Will be set by WebCodecsEncoder during initialize
+      onerror: null, // Will be set by WebCodecsEncoder during initialize
     };
     // Use globalThis directly for mocking to ensure visibility
     globalThis.Worker = vi.fn(() => mockWorkerInstance) as any;
@@ -179,10 +179,10 @@ describe("Mp4Encoder", () => {
   describe("isSupported", () => {
     it("should return true if VideoEncoder, AudioEncoder, and Worker are defined and configs supported", async () => {
       // beforeEach already sets these up to be truthy by default
-      // We also need to ensure isConfigSupported is called and resolves for the check in Mp4Encoder
-      // However, the static Mp4Encoder.isSupported() does not call isConfigSupported.
+      // We also need to ensure isConfigSupported is called and resolves for the check in WebCodecsEncoder
+      // However, the static WebCodecsEncoder.isSupported() does not call isConfigSupported.
       // It only checks for the presence of the global objects.
-      expect(Mp4Encoder.isSupported()).toBe(true);
+      expect(WebCodecsEncoder.isSupported()).toBe(true);
     });
 
     it("should return false if VideoEncoder is not defined", () => {
@@ -190,7 +190,7 @@ describe("Mp4Encoder", () => {
       delete globalThis.VideoEncoder;
       globalThis.AudioEncoder = vi.fn() as any;
       globalThis.Worker = vi.fn() as any;
-      expect(Mp4Encoder.isSupported()).toBe(false);
+      expect(WebCodecsEncoder.isSupported()).toBe(false);
     });
 
     it("should return false if AudioEncoder is not defined", () => {
@@ -198,7 +198,7 @@ describe("Mp4Encoder", () => {
       // @ts-ignore
       delete globalThis.AudioEncoder;
       globalThis.Worker = vi.fn() as any;
-      expect(Mp4Encoder.isSupported()).toBe(false);
+      expect(WebCodecsEncoder.isSupported()).toBe(false);
     });
 
     it("should return false if Worker is not defined", () => {
@@ -206,7 +206,7 @@ describe("Mp4Encoder", () => {
       globalThis.AudioEncoder = vi.fn() as any;
       // @ts-ignore
       delete globalThis.Worker;
-      expect(Mp4Encoder.isSupported()).toBe(false);
+      expect(WebCodecsEncoder.isSupported()).toBe(false);
     });
   });
 
@@ -221,8 +221,8 @@ describe("Mp4Encoder", () => {
         sampleRate: 44100,
         channels: 2,
       };
-      const encoder = new Mp4Encoder(inputConfig as EncoderConfig); // Cast to base EncoderConfig for input
-      expect(encoder).toBeInstanceOf(Mp4Encoder);
+      const encoder = new WebCodecsEncoder(inputConfig as EncoderConfig); // Cast to base EncoderConfig for input
+      expect(encoder).toBeInstanceOf(WebCodecsEncoder);
 
       // @ts-ignore access private member for test.
       // The type of encoder.config might be broader internally than the input EncoderConfig.
@@ -244,14 +244,14 @@ describe("Mp4Encoder", () => {
       expect(internalConfig.codec?.audio).toBe("aac"); // Adjusted expectation
 
       // TODO: Revisit testing of nested internalConfig.video and internalConfig.audio
-      // once the exact structure and typing within Mp4Encoder are clear and stable.
+      // once the exact structure and typing within WebCodecsEncoder are clear and stable.
       // For now, focus on values passed to the worker during initialize.
 
       // Example of how one might check if these exist, if they are indeed added:
       // expect(internalConfig.video).toBeDefined();
       // expect(internalConfig.audio).toBeDefined();
 
-      // If Mp4Encoder guarantees certain fully resolved codec strings in internalConfig.video.codec:
+      // If WebCodecsEncoder guarantees certain fully resolved codec strings in internalConfig.video.codec:
       // expect(internalConfig.video?.codec).toMatch(/^avc1\./);
       // expect(internalConfig.audio?.codec).toMatch(/^mp4a\.40\.2/);
     });
@@ -268,11 +268,11 @@ describe("Mp4Encoder", () => {
       sampleRate: 48000,
       channels: 2,
       // `container`, `latencyMode`, and specific `codec.*` are optional
-      // and will be defaulted by Mp4Encoder constructor if not provided.
+      // and will be defaulted by WebCodecsEncoder constructor if not provided.
     };
 
     it("should resolve when worker sends initialized message", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const initPromise = encoder.initialize({}); // Pass empty options object
 
       expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith({
@@ -302,7 +302,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("stores actual codecs from initialization", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const initPromise = encoder.initialize({});
       mockWorkerInstance.onmessage({
         data: {
@@ -318,7 +318,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("updates queue sizes from worker messages", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const initPromise = encoder.initialize({});
       mockWorkerInstance.onmessage({ data: { type: "initialized" } });
       await initPromise;
@@ -330,7 +330,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if worker posts an error during initialization", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const onErrorCallback = vi.fn();
       const initPromise = encoder.initialize({ onError: onErrorCallback });
 
@@ -360,7 +360,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if worker script itself throws an error (onerror)", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const onErrorCallback = vi.fn();
       // Initialize should set up the worker.onerror handler
       const initPromise = encoder.initialize({ onError: onErrorCallback });
@@ -390,7 +390,7 @@ describe("Mp4Encoder", () => {
     it("should reject if Required browser APIs are not supported", async () => {
       // @ts-ignore
       delete globalThis.Worker; // Example: Worker API is missing
-      const encoder = new Mp4Encoder({
+      const encoder = new WebCodecsEncoder({
         width: 100,
         height: 100,
         frameRate: 30,
@@ -399,10 +399,10 @@ describe("Mp4Encoder", () => {
         sampleRate: 48000,
         channels: 1,
       });
-      await expect(encoder.initialize()).rejects.toThrow(Mp4EncoderError);
+      await expect(encoder.initialize()).rejects.toThrow(WebCodecsEncoderError);
       // @ts-ignore
       delete globalThis.VideoEncoder;
-      const encoder2 = new Mp4Encoder({
+      const encoder2 = new WebCodecsEncoder({
         width: 100,
         height: 100,
         frameRate: 30,
@@ -411,10 +411,10 @@ describe("Mp4Encoder", () => {
         sampleRate: 48000,
         channels: 1,
       });
-      await expect(encoder2.initialize()).rejects.toThrow(Mp4EncoderError);
+      await expect(encoder2.initialize()).rejects.toThrow(WebCodecsEncoderError);
       // @ts-ignore
       delete globalThis.AudioEncoder;
-      const encoder3 = new Mp4Encoder({
+      const encoder3 = new WebCodecsEncoder({
         width: 100,
         height: 100,
         frameRate: 30,
@@ -423,11 +423,11 @@ describe("Mp4Encoder", () => {
         sampleRate: 48000,
         channels: 1,
       });
-      await expect(encoder3.initialize()).rejects.toThrow(Mp4EncoderError);
+      await expect(encoder3.initialize()).rejects.toThrow(WebCodecsEncoderError);
     });
 
     it("should pass totalFrames to worker if provided", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const totalFrames = 150;
       const initPromise = encoder.initialize({ totalFrames });
 
@@ -454,7 +454,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should set onProgress callback if provided and worker sends progress", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const onProgress = vi.fn();
       const initPromise = encoder.initialize({ onProgress });
       if (mockWorkerInstance.onmessage) {
@@ -466,7 +466,7 @@ describe("Mp4Encoder", () => {
       }
       await initPromise;
 
-      // Ensure onmessage is set on the worker instance by Mp4Encoder
+      // Ensure onmessage is set on the worker instance by WebCodecsEncoder
       expect(mockWorkerInstance.onmessage).toBeTypeOf("function");
 
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -488,7 +488,7 @@ describe("Mp4Encoder", () => {
         onmessage: null,
         onerror: null,
       } as any;
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const p = encoder.initialize({ worker: customWorker as any });
       expect(globalThis.Worker).not.toHaveBeenCalled();
       if (customWorker.onmessage) {
@@ -501,7 +501,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("uses a custom worker script URL if provided", async () => {
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const initPromise = encoder.initialize({ workerScriptUrl: "custom.js" });
       expect(globalThis.Worker).toHaveBeenCalledWith("custom.js", {
         type: "module",
@@ -518,7 +518,7 @@ describe("Mp4Encoder", () => {
         close: vi.fn(),
       }));
       globalThis.AudioContext = AudioContextMock as any;
-      const encoder = new Mp4Encoder(baseConfig);
+      const encoder = new WebCodecsEncoder(baseConfig);
       const initPromise = encoder.initialize({ useAudioWorklet: true });
       expect(AudioContextMock).toHaveBeenCalled();
       if (mockWorkerInstance.onmessage) {
@@ -533,7 +533,7 @@ describe("Mp4Encoder", () => {
       // @ts-ignore
       delete globalThis.AudioContext; // AudioContext を未定義にする
 
-      const encoder = new Mp4Encoder({
+      const encoder = new WebCodecsEncoder({
         width: 640,
         height: 480,
         frameRate: 30,
@@ -546,11 +546,11 @@ describe("Mp4Encoder", () => {
         await encoder.initialize({ useAudioWorklet: true });
         throw new Error("Should have rejected"); // テストが失敗することを確認するためのエラー
       } catch (e: any) {
-        expect(e).toBeInstanceOf(Mp4EncoderError);
+        expect(e).toBeInstanceOf(WebCodecsEncoderError);
         // initialize内でエラーがラップされるため、エラータイプと根本原因のメッセージを確認
         expect(e.type).toBe(EncoderErrorType.InitializationFailed);
         expect(e.message).toContain("Failed to initialize worker");
-        expect(e.cause).toBeInstanceOf(Mp4EncoderError);
+        expect(e.cause).toBeInstanceOf(WebCodecsEncoderError);
         expect(e.cause.type).toBe(EncoderErrorType.NotSupported);
         expect(e.cause.message).toBe(
           "AudioContext not available for AudioWorklet.",
@@ -574,7 +574,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("should resolve when a frame is added successfully", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       const initPromise = encoder.initialize({}); // Pass empty options object
       // Ensure onmessage is set by encoder.initialize() before we try to use it
       // expect(mockWorkerInstance.onmessage).toBeTypeOf("function"); // This might be too early if initialize is async and not awaited yet
@@ -606,7 +606,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if encoder not initialized", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       await expect(
         encoder.addVideoFrame(
           new globalThis.VideoFrame(document.createElement("canvas"), {
@@ -618,7 +618,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should propagate errors from worker postMessage if it throws", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       const onError = vi.fn();
       const initPromise = encoder.initialize({ onError: onError });
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -662,7 +662,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("should create a VideoFrame from an HTMLCanvasElement and post it", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -687,7 +687,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should accept OffscreenCanvas", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -715,7 +715,7 @@ describe("Mp4Encoder", () => {
         maxQueueDepth: 0,
       };
       const onProgress = vi.fn();
-      const encoder = new Mp4Encoder(cfg);
+      const encoder = new WebCodecsEncoder(cfg);
       const initPromise = encoder.initialize({ onProgress });
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -740,7 +740,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should propagate errors from worker postMessage", async () => {
-      const encoder = new Mp4Encoder(baseVideoConfig);
+      const encoder = new WebCodecsEncoder(baseVideoConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -776,7 +776,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("should resolve when audio data is added", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const initPromise = encoder.initialize({});
       // initialize の完了を待ち、worker からの "initialized" メッセージ受信をシミュレート
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -804,7 +804,7 @@ describe("Mp4Encoder", () => {
 
     it("should resolve immediately when audio disabled (audioBitrate is 0)", async () => {
       const cfg: EncoderConfig = { ...baseAudioConfig, audioBitrate: 0 };
-      const encoder = new Mp4Encoder(cfg);
+      const encoder = new WebCodecsEncoder(cfg);
 
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -827,14 +827,14 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if encoder not initialized", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       await expect(encoder.addAudioBuffer({} as AudioBuffer)).rejects.toThrow(
         "Encoder not initialized or already finalized",
       );
     });
 
     it("should propagate errors when gathering channel data", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const onError = vi.fn();
       const initPromise = encoder.initialize({ onError });
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -864,7 +864,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject when channel count does not match config", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -890,7 +890,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("should resolve when AudioData is added", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -932,7 +932,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should update nextAudioTimestamp if audioData.timestamp is null", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -1004,7 +1004,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject and call onError if copyTo fails", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const onErrorCallback = vi.fn();
       const initPromise = encoder.initialize({ onError: onErrorCallback });
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -1037,7 +1037,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject when AudioData channels do not match config", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -1061,7 +1061,7 @@ describe("Mp4Encoder", () => {
 
     it("should resolve immediately when audio disabled", async () => {
       const cfg: EncoderConfig = { ...baseAudioConfig, audioBitrate: 0 };
-      const encoder = new Mp4Encoder(cfg);
+      const encoder = new WebCodecsEncoder(cfg);
 
       const initPromise = encoder.initialize({});
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -1079,7 +1079,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if encoder not initialized", async () => {
-      const encoder = new Mp4Encoder(baseAudioConfig);
+      const encoder = new WebCodecsEncoder(baseAudioConfig);
       await expect(encoder.addAudioData({} as AudioData)).rejects.toThrow(
         "Encoder not initialized or already finalized",
       );
@@ -1087,7 +1087,7 @@ describe("Mp4Encoder", () => {
   });
 
   describe("finalize", () => {
-    let encoder: Mp4Encoder;
+    let encoder: WebCodecsEncoder;
     const mockConfig = {
       width: 640,
       height: 480,
@@ -1099,7 +1099,7 @@ describe("Mp4Encoder", () => {
     };
 
     beforeEach(async () => {
-      encoder = new Mp4Encoder(mockConfig);
+      encoder = new WebCodecsEncoder(mockConfig);
       const initPromise = encoder.initialize();
       if (mockWorkerInstance.onmessage) {
         mockWorkerInstance.onmessage({
@@ -1133,11 +1133,11 @@ describe("Mp4Encoder", () => {
     });
 
     it("should reject if not initialized", async () => {
-      const uninitializedEncoder = new Mp4Encoder(mockConfig); // New instance, not initialized
+      const uninitializedEncoder = new WebCodecsEncoder(mockConfig); // New instance, not initialized
       try {
         await uninitializedEncoder.finalize();
       } catch (e: any) {
-        expect(e).toBeInstanceOf(Mp4EncoderError);
+        expect(e).toBeInstanceOf(WebCodecsEncoderError);
         expect(e.type).toBe(EncoderErrorType.InternalError); // Or .Cancelled if it defaults to cancelled
         expect(e.message).toContain(
           "Encoder not initialized or already finalized",
@@ -1159,7 +1159,7 @@ describe("Mp4Encoder", () => {
       try {
         await finalizePromise;
       } catch (e: any) {
-        expect(e).toBeInstanceOf(Mp4EncoderError);
+        expect(e).toBeInstanceOf(WebCodecsEncoderError);
         expect(e.type).toBe(EncoderErrorType.MuxingFailed);
         expect(e.message).toBe(errorMessage);
       }
@@ -1193,7 +1193,7 @@ describe("Mp4Encoder", () => {
         await encoder.finalize();
         throw new Error("Should have rejected");
       } catch (e: any) {
-        expect(e).toBeInstanceOf(Mp4EncoderError);
+        expect(e).toBeInstanceOf(WebCodecsEncoderError);
         expect(e.type).toBe(EncoderErrorType.Cancelled);
         expect(e.message).toBe("Encoder cancelled");
       }
@@ -1204,7 +1204,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should warn and reject if finalize is called multiple times while the first is still pending", async () => {
-      encoder = new Mp4Encoder(mockConfig); // 新しいインスタンスを作成して isCancelled を false に
+      encoder = new WebCodecsEncoder(mockConfig); // 新しいインスタンスを作成して isCancelled を false に
       const initPromise = encoder.initialize();
       if (mockWorkerInstance.onmessage) {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -1225,7 +1225,7 @@ describe("Mp4Encoder", () => {
         finalizeError = e;
       }
 
-      expect(finalizeError).toBeInstanceOf(Mp4EncoderError);
+      expect(finalizeError).toBeInstanceOf(WebCodecsEncoderError);
       expect(finalizeError.type).toBe(EncoderErrorType.InternalError);
       expect(finalizeError.message).toBe("Finalize called multiple times.");
       expect(consoleWarnSpy).toHaveBeenCalledWith("Finalize already called.");
@@ -1257,7 +1257,7 @@ describe("Mp4Encoder", () => {
 
     it("should initialize with latencyMode: realtime and call onData for dataChunks", async () => {
       const onDataCallback = vi.fn();
-      const encoder = new Mp4Encoder(baseRealtimeConfig);
+      const encoder = new WebCodecsEncoder(baseRealtimeConfig);
       const initPromise = encoder.initialize({ onData: onDataCallback });
 
       expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith(
@@ -1315,7 +1315,7 @@ describe("Mp4Encoder", () => {
 
     it("finalize() should resolve with an empty Uint8Array in realtime mode", async () => {
       const onDataCallback = vi.fn();
-      const realtimeEncoder = new Mp4Encoder(baseRealtimeConfig);
+      const realtimeEncoder = new WebCodecsEncoder(baseRealtimeConfig);
       const initPromise = realtimeEncoder.initialize({
         onData: onDataCallback,
       }); // Promise を取得
@@ -1360,7 +1360,7 @@ describe("Mp4Encoder", () => {
 
     it("finalize() should resolve with null if worker sends null in realtime mode", async () => {
       const onDataCallback = vi.fn();
-      const realtimeEncoder = new Mp4Encoder(baseRealtimeConfig);
+      const realtimeEncoder = new WebCodecsEncoder(baseRealtimeConfig);
       const initPromise = realtimeEncoder.initialize({
         onData: onDataCallback,
       });
@@ -1404,7 +1404,7 @@ describe("Mp4Encoder", () => {
         ...baseRealtimeConfig,
         latencyMode: "quality",
       };
-      const encoder = new Mp4Encoder(qualityConfig);
+      const encoder = new WebCodecsEncoder(qualityConfig);
 
       const initPromise = encoder.initialize({ onData: onDataCallback });
       if (typeof mockWorkerInstance.onmessage === "function") {
@@ -1442,7 +1442,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("should call onInitializeError if cancelled during initialization", async () => {
-      const encoder = new Mp4Encoder(config);
+      const encoder = new WebCodecsEncoder(config);
       const onInitializeErrorSpy = vi.fn();
       const onErrorSpy = vi.fn();
 
@@ -1480,7 +1480,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("should call onFinalizedPromise.reject if cancelled during finalization", async () => {
-      const encoder = new Mp4Encoder(config);
+      const encoder = new WebCodecsEncoder(config);
       const initProcess = encoder.initialize(); // まずは正常に初期化
       if (mockWorkerInstance.onmessage) {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });
@@ -1537,7 +1537,7 @@ describe("Mp4Encoder", () => {
     };
 
     it("cleans up when worker sends cancelled", async () => {
-      const encoder = new Mp4Encoder(config);
+      const encoder = new WebCodecsEncoder(config);
       const initPromise = encoder.initialize({}); // Store the promise
       // Simulate worker sending 'initialized' message before awaiting initPromise
       if (mockWorkerInstance.onmessage) {
@@ -1552,7 +1552,7 @@ describe("Mp4Encoder", () => {
     });
 
     it("warns on unknown message type", async () => {
-      const encoder = new Mp4Encoder(config);
+      const encoder = new WebCodecsEncoder(config);
       const initPromise = encoder.initialize({}); // Store the promise
       // Simulate worker sending 'initialized' message before awaiting initPromise
       if (mockWorkerInstance.onmessage) {
@@ -1569,14 +1569,14 @@ describe("Mp4Encoder", () => {
         mockWorkerInstance.onmessage({ data: { type: "bogus" } as any }); // Cast to any if type is not in MainThreadMessage
       }
       expect(warnSpy).toHaveBeenCalledWith(
-        "Mp4Encoder: Unknown message from worker:",
+        "WebCodecsEncoder: Unknown message from worker:",
         { type: "bogus" },
       );
       warnSpy.mockRestore();
     });
 
     it("rejects initialize promise when cancelled early", async () => {
-      const encoder = new Mp4Encoder(config);
+      const encoder = new WebCodecsEncoder(config);
       const initPromise = encoder.initialize(); // Don't await here
       encoder.cancel();
       await expect(initPromise).rejects.toThrow("Operation cancelled by user."); // Adjusted message
@@ -1597,7 +1597,7 @@ describe("Mp4Encoder", () => {
       }));
       globalThis.AudioContext = AudioContextMock as any;
 
-      const encoder = new Mp4Encoder({ ...config });
+      const encoder = new WebCodecsEncoder({ ...config });
       const initPromise = encoder.initialize({ useAudioWorklet: true });
       if (mockWorkerInstance.onmessage) {
         mockWorkerInstance.onmessage({ data: { type: "initialized" } });

--- a/test/mediastream-recorder.test.ts
+++ b/test/mediastream-recorder.test.ts
@@ -9,12 +9,12 @@ import {
 } from "vitest";
 import type { EncoderConfig } from "../src/types";
 import { MediaStreamRecorder } from "../src/mediastream-recorder";
-import { Mp4Encoder } from "../src/encoder";
+import { WebCodecsEncoder } from "../src/encoder";
 
 let encoderInstance: any;
 
 vi.mock("../src/encoder", () => {
-  const MockMp4Encoder = vi.fn(() => {
+  const MockWebCodecsEncoder = vi.fn(() => {
     encoderInstance = {
       initialize: vi.fn().mockResolvedValue(undefined),
       addVideoFrame: vi.fn().mockResolvedValue(undefined),
@@ -27,8 +27,8 @@ vi.mock("../src/encoder", () => {
     };
     return encoderInstance;
   });
-  (MockMp4Encoder as any).isSupported = vi.fn(() => true);
-  return { Mp4Encoder: MockMp4Encoder };
+  (MockWebCodecsEncoder as any).isSupported = vi.fn(() => true);
+  return { WebCodecsEncoder: MockWebCodecsEncoder };
 });
 
 // @ts-ignore - Ignoring VideoFrame/AudioData type complexity for mock values
@@ -133,7 +133,7 @@ describe("MediaStreamRecorder", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (Mp4Encoder as any).isSupported.mockReturnValue(true);
+    (WebCodecsEncoder as any).isSupported.mockReturnValue(true);
     originalMediaStreamTrackProcessor = (globalThis as any)
       .MediaStreamTrackProcessor;
     (globalThis as any).MediaStreamTrackProcessor = FakeProcessor;
@@ -155,15 +155,15 @@ describe("MediaStreamRecorder", () => {
   });
 
   describe("isSupported", () => {
-    it("should return true if MediaStreamTrackProcessor and Mp4Encoder are supported", () => {
+    it("should return true if MediaStreamTrackProcessor and WebCodecsEncoder are supported", () => {
       expect(MediaStreamRecorder.isSupported()).toBe(true);
     });
     it("should return false if MediaStreamTrackProcessor is not defined", () => {
       (globalThis as any).MediaStreamTrackProcessor = undefined;
       expect(MediaStreamRecorder.isSupported()).toBe(false);
     });
-    it("should return false if Mp4Encoder.isSupported() returns false", () => {
-      (Mp4Encoder as any).isSupported.mockReturnValue(false);
+    it("should return false if WebCodecsEncoder.isSupported() returns false", () => {
+      (WebCodecsEncoder as any).isSupported.mockReturnValue(false);
       expect(MediaStreamRecorder.isSupported()).toBe(false);
     });
   });
@@ -172,7 +172,7 @@ describe("MediaStreamRecorder", () => {
     const recorder = new MediaStreamRecorder(config);
     await recorder.startRecording(mediaStream);
     await Promise.resolve();
-    expect(Mp4Encoder).toHaveBeenCalledWith(config);
+    expect(WebCodecsEncoder).toHaveBeenCalledWith(config);
     expect(encoderInstance.initialize).toHaveBeenCalled();
     expect(encoderInstance.addVideoFrame).toHaveBeenCalled();
     expect(encoderInstance.addAudioData).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- rename `Mp4Encoder` to `WebCodecsEncoder`
- rename `Mp4EncoderError` to `WebCodecsEncoderError`
- update examples, README and tests

## Testing
- `npm run format`
- `npm run type-check` *(fails: Cannot find type definition file for 'dom-webcodecs')*
- `npm run lint:fix` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: vitest not found)*