### PR TITLE
Add Puppeteer integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts src/worker.ts src/audio-worklet-processor.ts --format esm,cjs --dts --sourcemap",
-    "test": "vitest run --coverage",
+    "test": "npm run build && vitest run --coverage",
     "lint": "eslint src/**/*.ts test/**/*.ts",
     "lint:fix": "eslint src/**/*.ts test/**/*.ts --fix",
     "format": "prettier --write src/**/*.ts test/**/*.ts",
@@ -50,7 +50,8 @@
     "prettier": "^3.2.5",
     "tsup": "^8.0.2",
     "typescript": "5.4.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "puppeteer": "^22.0.0"
   },
   "files": [
     "dist"

--- a/test/integration/encode-browser.test.ts
+++ b/test/integration/encode-browser.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @vitest-environment node
+ */
+import { test, afterAll, expect } from "vitest";
+import puppeteer from "puppeteer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { execSync } from "child_process";
+
+let browser: any = null;
+
+afterAll(async () => {
+  if (browser) {
+    await browser.close();
+  }
+});
+
+test.concurrent("encodes video and audio in browser", async () => {
+  // Build the library to ensure dist/index.mjs exists
+  execSync("npm run build", { stdio: "inherit" });
+  const distPath = join(__dirname, "../../dist/index.mjs");
+  const code = readFileSync(distPath, "utf8");
+  const moduleCode = Buffer.from(code).toString("base64");
+
+  browser = await puppeteer.launch({ args: ["--no-sandbox"] });
+  const page = await browser.newPage();
+  await page.goto("about:blank");
+
+  const result = await page.evaluate(async (encoded: string) => {
+    const { WebCodecsEncoder } = await import(
+      `data:text/javascript;base64,${encoded}`
+    );
+
+    const config = {
+      width: 64,
+      height: 64,
+      frameRate: 5,
+      videoBitrate: 100_000,
+      audioBitrate: 64_000,
+      sampleRate: 48000,
+      channels: 1,
+    } as const;
+
+    const encoder = new WebCodecsEncoder(config);
+    await encoder.initialize();
+
+    const canvas = document.createElement("canvas");
+    canvas.width = config.width;
+    canvas.height = config.height;
+    const ctx = canvas.getContext("2d")!;
+    for (let i = 0; i < 2; i++) {
+      ctx.fillStyle = `rgb(${i * 20}, 0, 0)`;
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      await encoder.addCanvasFrame(canvas);
+    }
+
+    const audioCtx = new AudioContext({ sampleRate: config.sampleRate });
+    const buffer = audioCtx.createBuffer(
+      config.channels,
+      audioCtx.sampleRate / 2,
+      audioCtx.sampleRate,
+    );
+    await encoder.addAudioBuffer(buffer);
+
+    const data = await encoder.finalize();
+    return Array.from(data);
+  }, moduleCode);
+
+  const uint8 = Uint8Array.from(result as number[]);
+  expect(uint8.byteLength).toBeGreaterThan(0);
+  expect(uint8[0] === 0x00 || uint8[0] === 0x1a).toBe(true);
+});

--- a/test/integration/puppeteer.d.ts
+++ b/test/integration/puppeteer.d.ts
@@ -1,0 +1,4 @@
+declare module "puppeteer" {
+  const puppeteer: any;
+  export default puppeteer;
+}


### PR DESCRIPTION
## Summary
- install puppeteer dev dependency
- add encode-browser integration test using Puppeteer
- build before testing via npm script

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test` *(fails: Cannot find package 'puppeteer' imported)*