### PR TITLE
Remove canvas frame close

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -394,11 +394,7 @@ export class WebCodecsEncoder {
       timestamp,
       duration: 1_000_000 / this.config.frameRate,
     });
-    try {
-      await this.addVideoFrame(frame);
-    } finally {
-      frame.close();
-    }
+    await this.addVideoFrame(frame);
   }
 
   public async addAudioBuffer(audioBuffer: AudioBuffer): Promise<void> {


### PR DESCRIPTION
## Summary
- remove frame.close() in addCanvasFrame since worker handles it

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
