### PR TITLE
Fix canvas frame cleanup on error

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -394,7 +394,12 @@ export class WebCodecsEncoder {
       timestamp,
       duration: 1_000_000 / this.config.frameRate,
     });
-    await this.addVideoFrame(frame);
+    try {
+      await this.addVideoFrame(frame);
+    } catch (err) {
+      frame.close();
+      throw err;
+    }
   }
 
   public async addAudioBuffer(audioBuffer: AudioBuffer): Promise<void> {


### PR DESCRIPTION
## Summary
- prevent memory leak when canvas frame posting fails

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
