### PR TITLE
Fix frame closing after encode

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -669,7 +669,14 @@ class EncoderWorker {
           ? ({ keyFrame: true } as VideoEncoderEncodeOptions)
           : undefined;
       this.videoEncoder.encode(frame, opts as any);
-      frame.close();
+      // Some implementations may automatically close the transferred frame
+      // when passed to `encode`. Guard against potential errors from calling
+      // `close()` on an already-consumed frame.
+      try {
+        frame.close();
+      } catch (closeErr) {
+        logger.warn("Worker: Ignored error closing VideoFrame", closeErr);
+      }
       this.videoFrameCount++;
       this.processedFrames++;
       const progressMessage: any = {


### PR DESCRIPTION
## Notes
- Guarded `VideoFrame.close()` in worker to avoid errors if `VideoEncoder.encode` already consumes the frame.

## Summary
- prevent errors from double closing video frames

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
