### PR TITLE
Improve cancel message handling

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -590,6 +590,13 @@ export class WebCodecsEncoder {
     const message: WorkerMessage = { type: "cancel" };
     this.worker.postMessage(message);
 
+    // Ignore any further messages except the worker's acknowledgement
+    this.worker.onmessage = (event: MessageEvent<MainThreadMessage>) => {
+      if (event.data.type === "cancelled" || event.data.type === "error") {
+        this.handleWorkerMessage(event.data);
+      }
+    };
+
     // Reject pending promises
     const cancelError = new WebCodecsEncoderError(
       EncoderErrorType.Cancelled,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -840,10 +840,16 @@ class EncoderWorker {
     if (this.isCancelled) return;
     this.isCancelled = true;
     logger.log("Worker: Received cancel signal.");
+
+    // Ensure the main thread is notified even if cleanup throws
+    this.postMessageToMainThread({ type: "cancelled" } as MainThreadMessage);
+
     this.videoEncoder?.close();
     this.audioEncoder?.close();
+
+    // Cleanup without resetting the cancelled state so that any queued
+    // messages after this point are ignored.
     this.cleanup(false);
-    this.postMessageToMainThread({ type: "cancelled" } as MainThreadMessage);
   }
 
   cleanup(resetCancelled: boolean = true): void {


### PR DESCRIPTION
## Summary
- ignore all messages except `cancelled` or `error` after calling `cancel`
- send `cancelled` acknowledgement before worker cleanup

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
