### PR TITLE
Handle null finalization output

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -270,7 +270,11 @@ export class WebCodecsEncoder {
               EncoderErrorType.MuxingFailed,
               "Finalized with null output in non-realtime mode.",
             );
-            this.onFinalizedPromise?.reject(err);
+            if (this.onFinalizedPromise) {
+              this.onFinalizedPromise.reject(err);
+            } else {
+              this.onInitializeError?.(err);
+            }
             this.handleError(err); // Ensure onErrorCallback is called
           }
         }

--- a/test/encoder.test.ts
+++ b/test/encoder.test.ts
@@ -1165,6 +1165,21 @@ describe("WebCodecsEncoder", () => {
       }
     });
 
+    it("should reject with explicit error when finalized with null output", async () => {
+      const finalizePromise = encoder.finalize();
+
+      if (mockWorkerInstance.onmessage) {
+        mockWorkerInstance.onmessage({
+          data: { type: "finalized", output: null },
+        });
+      }
+
+      await expect(finalizePromise).rejects.toMatchObject({
+        type: EncoderErrorType.MuxingFailed,
+        message: "Finalized with null output in non-realtime mode.",
+      });
+    });
+
     it("should reject if finalize is called multiple times", async () => {
       // encoder is initialized in beforeEach
 


### PR DESCRIPTION
## Summary
- propagate explicit error when finalized message has null output
- add test to cover null output branch

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
