### PR TITLE
Fix AudioWorklet channel checks

### DIFF
--- a/src/audio-worklet-processor.ts
+++ b/src/audio-worklet-processor.ts
@@ -36,11 +36,11 @@ class EncoderAudioWorkletProcessor extends AudioWorkletProcessor {
     if (!input || input.length === 0) return true;
 
     // At least one channel must exist, and it must have some frames.
-    // input[0] is the first channel. If it doesn't exist or has no frames, consider it invalid.
-    if (!input[0] || input[0].length === 0) return true;
+    const firstChannel = input[0];
+    if (!firstChannel || firstChannel.length === 0) return true;
 
     const numChannels = input.length;
-    const numFrames = input[0].length; // This will be > 0 due to the check above
+    const numFrames = firstChannel.length; // This will be > 0 due to the check above
     const buffers: Float32Array[] = [];
     for (let c = 0; c < numChannels; c++) {
       const copy = new Float32Array(input[c]);

--- a/test/audio-worklet-processor.test.ts
+++ b/test/audio-worklet-processor.test.ts
@@ -157,6 +157,18 @@ describe("EncoderAudioWorkletProcessor", () => {
       expect(mockWorkerSidePort.postMessage).not.toHaveBeenCalled();
     });
 
+    it("should return true when first channel array is undefined or empty", () => {
+      let inputs: Float32Array[][] = [[undefined as any]];
+      expect(processor.process(inputs, [], {})).toBe(true);
+      expect(mockWorkerSidePort.postMessage).not.toHaveBeenCalled();
+
+      mockWorkerSidePort.postMessage.mockClear();
+
+      inputs = [[new Float32Array(0)]];
+      expect(processor.process(inputs, [], {})).toBe(true);
+      expect(mockWorkerSidePort.postMessage).not.toHaveBeenCalled();
+    });
+
     it("should post audio data to workerPort if inputs are valid", () => {
       const inputData = [
         new Float32Array([0.1, 0.2, 0.3]),


### PR DESCRIPTION
## Summary
- ensure the first channel exists before using its length
- test edge cases for undefined or empty channel arrays

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint:fix`
- `npm test`
