### PR TITLE
Add typed encoder getters and remove any casts

### DIFF
--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -1,5 +1,10 @@
 import { EncoderErrorType, WebCodecsEncoderError } from "./types";
-import type { EncoderConfig, MainThreadMessage, WorkerMessage } from "./types";
+import type {
+  EncoderConfig,
+  MainThreadMessage,
+  WorkerMessage,
+  ConnectAudioPortMessage,
+} from "./types";
 import logger from "./logger";
 
 // Define the onData callback type for real-time streaming
@@ -138,7 +143,7 @@ export class WebCodecsEncoder {
             const script =
               options?.workerScriptUrl ??
               new URL("./worker.js", import.meta.url);
-            this.worker = new Worker(script as any, { type: "module" });
+            this.worker = new Worker(script, { type: "module" });
           }
 
           this.worker.onmessage = (event: MessageEvent<MainThreadMessage>) => {
@@ -214,8 +219,8 @@ export class WebCodecsEncoder {
 
     switch (message.type) {
       case "initialized":
-        this.actualVideoCodec = (message as any).actualVideoCodec ?? null;
-        this.actualAudioCodec = (message as any).actualAudioCodec ?? null;
+        this.actualVideoCodec = message.actualVideoCodec ?? null;
+        this.actualAudioCodec = message.actualAudioCodec ?? null;
         this.onInitialized?.();
         this.onInitialized = null;
         this.onInitializeError = null;
@@ -651,7 +656,9 @@ export class WebCodecsEncoder {
   }
 
   private async setupAudioWorklet(): Promise<void> {
-    const AudioContextCtor: any = (globalThis as any).AudioContext;
+    const AudioContextCtor = (
+      globalThis as unknown as { AudioContext?: typeof AudioContext }
+    ).AudioContext;
     if (!AudioContextCtor) {
       const err = new WebCodecsEncoderError(
         EncoderErrorType.NotSupported,
@@ -691,10 +698,10 @@ export class WebCodecsEncoder {
     );
 
     const { port1, port2 } = new MessageChannel();
-    const connectMessage: WorkerMessage = {
+    const connectMessage: ConnectAudioPortMessage = {
       type: "connectAudioPort",
       port: port1,
-    } as any;
+    };
     this.worker!.postMessage(connectMessage, [port1]);
     this.audioWorkletNode.port.postMessage(
       { port: port2, sampleRate: this.config.sampleRate },

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,15 @@ export type ProgressCallback = (
   totalFrames?: number,
 ) => void;
 
+// --- Helper Types for environment-dependent constructors ---
+export type VideoEncoderConstructor = typeof VideoEncoder;
+export type AudioEncoderConstructor = typeof AudioEncoder;
+export type AudioDataConstructor = typeof AudioData;
+
+export type VideoEncoderGetter = () => VideoEncoderConstructor | undefined;
+export type AudioEncoderGetter = () => AudioEncoderConstructor | undefined;
+export type AudioDataGetter = () => AudioDataConstructor | undefined;
+
 // --- Custom Error for the library ---
 export enum EncoderErrorType {
   NotSupported = "not-supported",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -9,6 +9,9 @@ import type {
   FinalizeWorkerMessage,
   CancelWorkerMessage,
   MainThreadMessage,
+  VideoEncoderGetter,
+  AudioEncoderGetter,
+  AudioDataGetter,
 } from "./types";
 import { EncoderErrorType } from "./types";
 import logger from "./logger";
@@ -82,12 +85,17 @@ if (
   );
 }
 
-const getVideoEncoder = () =>
-  (self as any).VideoEncoder ?? (globalThis as any).VideoEncoder;
-const getAudioEncoder = () =>
-  (self as any).AudioEncoder ?? (globalThis as any).AudioEncoder;
-const getAudioData = () =>
-  (self as any).AudioData ?? (globalThis as any).AudioData;
+const getVideoEncoder: VideoEncoderGetter = () =>
+  (self as unknown as { VideoEncoder?: typeof VideoEncoder }).VideoEncoder ??
+  (globalThis as unknown as { VideoEncoder?: typeof VideoEncoder })
+    .VideoEncoder;
+const getAudioEncoder: AudioEncoderGetter = () =>
+  (self as unknown as { AudioEncoder?: typeof AudioEncoder }).AudioEncoder ??
+  (globalThis as unknown as { AudioEncoder?: typeof AudioEncoder })
+    .AudioEncoder;
+const getAudioData: AudioDataGetter = () =>
+  (self as unknown as { AudioData?: typeof AudioData }).AudioData ??
+  (globalThis as unknown as { AudioData?: typeof AudioData }).AudioData;
 
 class EncoderWorker {
   private videoEncoder: VideoEncoder | null = null;
@@ -108,7 +116,11 @@ class EncoderWorker {
     message: MainThreadMessage,
     transfer?: Transferable[],
   ): void {
-    self.postMessage(message, transfer as any);
+    if (transfer && transfer.length > 0) {
+      self.postMessage(message, transfer);
+    } else {
+      self.postMessage(message);
+    }
   }
 
   private defaultAvcCodecString(
@@ -142,14 +154,25 @@ class EncoderWorker {
     return null;
   }
 
-  private async isConfigSupportedWithHwFallback(
-    Ctor: any,
-    config: any,
+  private async isConfigSupportedWithHwFallback<
+    T extends (VideoEncoderConfig | AudioEncoderConfig) & {
+      hardwareAcceleration?:
+        | "prefer-hardware"
+        | "prefer-software"
+        | "no-preference";
+    },
+  >(
+    Ctor: {
+      isConfigSupported(
+        config: T,
+      ): Promise<{ supported?: boolean; config?: T }>;
+    },
+    config: T,
     label: string,
-  ) {
+  ): Promise<T | null> {
     // オリジナルの設定で試行
-    let support = await Ctor.isConfigSupported(config as any);
-    if (support?.supported) return support.config;
+    let support = await Ctor.isConfigSupported(config);
+    if (support?.supported && support.config) return support.config;
 
     // ハードウェアアクセラレーション設定がある場合のフォールバック処理
     const pref = config.hardwareAcceleration;
@@ -161,8 +184,8 @@ class EncoderWorker {
 
       if (altPref) {
         const opposite = { ...config, hardwareAcceleration: altPref };
-        support = await Ctor.isConfigSupported(opposite as any);
-        if (support?.supported) {
+        support = await Ctor.isConfigSupported(opposite);
+        if (support?.supported && support.config) {
           console.warn(
             `${label}: hardwareAcceleration preference '${pref}' not supported. Using '${altPref}'.`,
           );
@@ -171,10 +194,10 @@ class EncoderWorker {
       }
 
       // 設定なしを試す
-      const noPref = { ...config };
+      const noPref = { ...config } as T & { hardwareAcceleration?: undefined };
       delete noPref.hardwareAcceleration;
-      support = await Ctor.isConfigSupported(noPref as any);
-      if (support?.supported) {
+      support = await Ctor.isConfigSupported(noPref);
+      if (support?.supported && support.config) {
         console.warn(
           `${label}: hardwareAcceleration preference '${pref}' not supported. Using no preference.`,
         );
@@ -297,7 +320,7 @@ class EncoderWorker {
         : {}),
     };
 
-    const VideoEncoderCtor: any = getVideoEncoder();
+    const VideoEncoderCtor = getVideoEncoder();
     if (!VideoEncoderCtor) {
       this.postMessageToMainThread({
         type: "error",
@@ -311,10 +334,11 @@ class EncoderWorker {
     }
 
     // まず明示的に指定されたコーデックを試す
-    let support = await VideoEncoderCtor.isConfigSupported(videoEncoderConfig);
+    const initialSupport =
+      await VideoEncoderCtor.isConfigSupported(videoEncoderConfig);
 
-    if (support?.supported) {
-      finalVideoEncoderConfig = support.config as VideoEncoderConfig;
+    if (initialSupport?.supported && initialSupport.config) {
+      finalVideoEncoderConfig = initialSupport.config;
     } else {
       // 明示的な指定がされていないか、サポートされていない場合
       if (
@@ -336,22 +360,27 @@ class EncoderWorker {
           this.currentConfig.frameRate,
         );
 
-        const avcConfig = {
+        const avcConfig: VideoEncoderConfig & {
+          hardwareAcceleration?:
+            | "prefer-hardware"
+            | "prefer-software"
+            | "no-preference";
+        } = {
           ...videoEncoderConfig,
           codec: avcCodecString,
           ...(this.currentConfig.container === "mp4"
-            ? { avc: { format: "avc" } }
+            ? { avc: { format: "avc" as const } }
             : {}),
         };
 
-        support = await this.isConfigSupportedWithHwFallback(
+        const support = await this.isConfigSupportedWithHwFallback(
           VideoEncoderCtor,
           avcConfig,
           "VideoEncoder",
         );
 
         if (support) {
-          finalVideoEncoderConfig = support as VideoEncoderConfig;
+          finalVideoEncoderConfig = support;
         } else {
           this.postMessageToMainThread({
             type: "error",
@@ -373,7 +402,7 @@ class EncoderWorker {
         );
 
         if (result) {
-          finalVideoEncoderConfig = result as VideoEncoderConfig;
+          finalVideoEncoderConfig = result;
         } else {
           this.postMessageToMainThread({
             type: "error",
@@ -409,7 +438,7 @@ class EncoderWorker {
       });
       if (finalVideoEncoderConfig) {
         if (this.videoEncoder) {
-          this.videoEncoder.configure(finalVideoEncoderConfig as any);
+          this.videoEncoder.configure(finalVideoEncoderConfig);
         } else {
           this.postMessageToMainThread({
             type: "error",
@@ -624,7 +653,7 @@ class EncoderWorker {
           },
         });
         if (this.audioEncoder) {
-          this.audioEncoder.configure(finalAudioEncoderConfig as any);
+          this.audioEncoder.configure(finalAudioEncoderConfig);
         } else {
           this.postMessageToMainThread({
             type: "error",
@@ -668,7 +697,7 @@ class EncoderWorker {
         interval && this.videoFrameCount % interval === 0
           ? ({ keyFrame: true } as VideoEncoderEncodeOptions)
           : undefined;
-      this.videoEncoder.encode(frame, opts as any);
+      this.videoEncoder.encode(frame, opts);
       frame.close();
       this.videoFrameCount++;
       this.processedFrames++;
@@ -912,7 +941,7 @@ class EncoderWorker {
         default:
           console.warn(
             "Worker received unknown message type:",
-            (eventData as any)?.type,
+            (eventData as { type?: unknown }).type,
           );
       }
     } catch (error: any) {

--- a/test/worker-audio.test.ts
+++ b/test/worker-audio.test.ts
@@ -210,7 +210,6 @@ describe("handleAddAudioData", () => {
         videoQueueSize: 0,
         audioQueueSize: 0,
       },
-      undefined,
     );
   });
 
@@ -240,7 +239,6 @@ describe("handleAddAudioData", () => {
         videoQueueSize: 0,
         audioQueueSize: 0,
       },
-      undefined,
     );
   });
 
@@ -283,7 +281,6 @@ describe("handleAddAudioData", () => {
           type: "not-supported",
         },
       },
-      undefined,
     );
     (globalThis as any).AudioData = AudioDataOriginal;
     (mockSelf as any).AudioData = AudioDataOriginal;
@@ -334,7 +331,6 @@ describe("handleAddAudioData", () => {
           type: "audio-encoding-error",
         }),
       }),
-      undefined,
     );
     (globalThis as any).AudioData = AudioDataOriginal;
     (mockSelf as any).AudioData = AudioDataOriginal;
@@ -368,7 +364,6 @@ describe("handleAddAudioData", () => {
           stack: expect.any(String),
         },
       },
-      undefined,
     );
   });
 
@@ -411,7 +406,6 @@ describe("handleAddAudioData", () => {
           type: "configuration-error",
         },
       },
-      undefined,
     );
   });
 });
@@ -502,7 +496,6 @@ describe("handleConnectAudioPort", () => {
         videoQueueSize: 0,
         audioQueueSize: 0,
       },
-      undefined,
     );
   });
 });

--- a/test/worker-edge.test.ts
+++ b/test/worker-edge.test.ts
@@ -123,7 +123,6 @@ describe("worker self.onmessage error handling and cancellation edge cases", () 
     await global.self.onmessage({ data: initMessage } as MessageEvent);
     expect(mockSelf.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "initialized" }),
-      undefined,
     );
   });
 
@@ -132,7 +131,7 @@ describe("worker self.onmessage error handling and cancellation edge cases", () 
     await global.self.onmessage({ data: { type: "initialize", config } } as MessageEvent);
     mockSelf.postMessage.mockClear();
     await global.self.onmessage({ data: { type: "cancel" } } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith({ type: "cancelled" }, undefined);
+    expect(mockSelf.postMessage).toHaveBeenCalledWith({ type: "cancelled" });
     mockSelf.postMessage.mockClear();
     await global.self.onmessage({ data: { type: "cancel" } } as MessageEvent);
     expect(mockSelf.postMessage).not.toHaveBeenCalled();
@@ -158,9 +157,7 @@ describe("worker self.onmessage error handling and cancellation edge cases", () 
           stack: expect.any(String),
         }),
       }),
-      undefined,
     );
-
     mockSelf.VideoEncoder.isConfigSupported = originalVideoEncoderIsSupported;
     globalThis.VideoEncoder = mockSelf.VideoEncoder;
   });

--- a/test/worker-finalize.test.ts
+++ b/test/worker-finalize.test.ts
@@ -119,7 +119,6 @@ describe("handleFinalize", () => {
       expect(initErrorPost, "Worker initialization in handleFinalize beforeEach should not post an error").toBeUndefined();
       expect(mockSelf.postMessage).toHaveBeenCalledWith(
         expect.objectContaining({ type: "initialized" }),
-        undefined,
       );
       mockSelf.postMessage.mockClear();
     } else {
@@ -165,7 +164,6 @@ describe("handleFinalize", () => {
           type: "initialization-failed",
         }),
       }),
-      undefined,
     );
     mockSelf.postMessage.mockClear();
 
@@ -179,7 +177,6 @@ describe("handleFinalize", () => {
           type: "muxing-failed",
         },
       },
-      undefined,
     );
     specificTestMp4MuxerWrapperMock.mockImplementation(() => mockMuxerInstanceForWorker as any);
   });
@@ -199,7 +196,6 @@ describe("handleFinalize", () => {
           type: "muxing-failed",
         },
       },
-      undefined,
     );
   });
 
@@ -220,7 +216,6 @@ describe("handleFinalize", () => {
     expect(initErrorPost, "Error during realtime re-initialization").toBeUndefined();
     expect(mockSelf.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "initialized" }),
-      undefined,
     );
     mockSelf.postMessage.mockClear();
 
@@ -228,7 +223,6 @@ describe("handleFinalize", () => {
     await global.self.onmessage({ data: finalizeMessage } as MessageEvent);
     expect(mockSelf.postMessage).toHaveBeenCalledWith(
       { type: "finalized", output: null },
-      undefined,
     );
   });
 
@@ -249,7 +243,6 @@ describe("handleFinalize", () => {
           stack: expect.any(String),
         },
       },
-      undefined,
     );
   });
 
@@ -273,7 +266,6 @@ describe("handleFinalize", () => {
           type: "muxing-failed",
         },
       },
-      undefined,
     );
   });
 });

--- a/test/worker-init.test.ts
+++ b/test/worker-init.test.ts
@@ -61,14 +61,11 @@ describe("worker", () => {
     const initMessage: InitializeWorkerMessage = { type: "initialize", config };
     mockSelf.postMessage.mockClear();
     await global.self.onmessage({ data: initMessage } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith(
-      {
-        type: "initialized",
-        actualVideoCodec: "avc1.42001f",
-        actualAudioCodec: "mp4a.40.2",
-      },
-      undefined,
-    );
+    expect(mockSelf.postMessage).toHaveBeenCalledWith({
+      type: "initialized",
+      actualVideoCodec: "avc1.42001f",
+      actualAudioCodec: "mp4a.40.2",
+    });
 
     // Simulate receiving a finalize message
     mockSelf.postMessage.mockClear();
@@ -129,23 +126,17 @@ describe("worker", () => {
     // Initialize first (or part of it, enough to set up for cancel)
     const initMessage: InitializeWorkerMessage = { type: "initialize", config };
     await global.self.onmessage({ data: initMessage } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith(
-      {
-        type: "initialized",
-        actualVideoCodec: "avc1.42001f",
-        actualAudioCodec: "mp4a.40.2",
-      },
-      undefined,
-    );
+    expect(mockSelf.postMessage).toHaveBeenCalledWith({
+      type: "initialized",
+      actualVideoCodec: "avc1.42001f",
+      actualAudioCodec: "mp4a.40.2",
+    });
     mockSelf.postMessage.mockClear();
 
     // Simulate receiving a cancel message
     const cancelMessage: CancelWorkerMessage = { type: "cancel" };
     await global.self.onmessage({ data: cancelMessage } as MessageEvent);
-    expect(mockSelf.postMessage).toHaveBeenCalledWith(
-      { type: "cancelled" },
-      undefined,
-    );
+    expect(mockSelf.postMessage).toHaveBeenCalledWith({ type: "cancelled" });
 
     // After cancellation, other messages should be ignored
     mockSelf.postMessage.mockClear();
@@ -165,7 +156,6 @@ describe("worker", () => {
         actualVideoCodec: "avc1.42001f",
         actualAudioCodec: "mp4a.40.2",
       },
-      undefined,
     );
   });
 
@@ -195,7 +185,6 @@ describe("worker", () => {
         type: "initialized", 
         actualVideoCodec: "avc1.deadbeef" 
       }),
-      undefined,
     );
   });
 
@@ -235,7 +224,6 @@ describe("worker", () => {
       expect.objectContaining({
         type: "initialized"
       }),
-      undefined,
     );
   });
 
@@ -277,7 +265,6 @@ describe("worker", () => {
           type: "not-supported",
         },
       },
-      undefined,
     );
   });
 
@@ -297,7 +284,6 @@ describe("worker", () => {
     );
     expect(mockSelf.postMessage).toHaveBeenCalledWith(
       { type: "initialized", actualVideoCodec: "avc1.42001f", actualAudioCodec: null },
-      undefined,
     );
   });
 
@@ -327,7 +313,6 @@ describe("worker", () => {
             type: "not-supported",
           },
         },
-        undefined,
       );
     });
 
@@ -355,7 +340,6 @@ describe("worker", () => {
             type: "not-supported",
           },
         },
-        undefined,
       );
     });
 
@@ -394,7 +378,6 @@ describe("worker", () => {
             stack: expect.any(String),
           },
         },
-        undefined,
       );
     });
 
@@ -436,7 +419,6 @@ describe("worker", () => {
             stack: expect.any(String),
           },
         },
-        undefined,
       );
     });
 
@@ -458,7 +440,6 @@ describe("worker", () => {
             type: "initialization-failed",
           },
         },
-        undefined,
       );
     });
 
@@ -483,7 +464,6 @@ describe("worker", () => {
       await global.self.onmessage({ data: initMessage } as MessageEvent);
       expect(mockSelf.postMessage).toHaveBeenCalledWith(
         { type: "initialized", actualVideoCodec: "vp09.00.50.08", actualAudioCodec: "opus" },
-        undefined,
       );
     });
 
@@ -530,7 +510,6 @@ describe("worker", () => {
           type: "initialized",
           actualVideoCodec: expect.stringMatching(/^avc1\./),
         }),
-        undefined,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -566,7 +545,6 @@ describe("worker", () => {
             type: "not-supported",
           }),
         }),
-        undefined,
       );
     });
 
@@ -610,7 +588,6 @@ describe("worker", () => {
           type: "initialized",
           actualAudioCodec: "mp4a.40.2.test",
         }),
-        undefined,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -654,7 +631,6 @@ describe("worker", () => {
           type: "initialized",
           actualAudioCodec: "opus.test",
         }),
-        undefined,
       );
       consoleWarnSpy.mockRestore();
     });
@@ -686,7 +662,6 @@ describe("worker", () => {
             type: "not-supported",
           },
         },
-        undefined,
       );
     });
 
@@ -713,7 +688,6 @@ describe("worker", () => {
             type: "configuration-error",
           },
         },
-        undefined,
       );
     });
 
@@ -739,7 +713,6 @@ describe("worker", () => {
             type: "not-supported",
           },
         },
-        undefined,
       );
       globalThis.VideoEncoder = originalVideoEncoder;
       mockSelf.VideoEncoder = originalMockSelfVideoEncoder;
@@ -767,7 +740,6 @@ describe("worker", () => {
             type: "not-supported",
           },
         },
-        undefined,
       );
       globalThis.AudioEncoder = originalAudioEncoder;
       mockSelf.AudioEncoder = originalMockSelfAudioEncoder;
@@ -828,7 +800,6 @@ describe("worker", () => {
             stack: expect.any(String),
           }),
         }),
-        undefined,
       );
 
       (mockSelf as any).VideoEncoder = originalVideoEncoderCtor as any;
@@ -891,7 +862,6 @@ describe("worker", () => {
             stack: expect.any(String),
           }),
         }),
-        undefined,
       );
 
       (mockSelf as any).VideoEncoder = originalVideoEncoderCtorForThisTest as any;
@@ -927,8 +897,7 @@ describe("worker", () => {
         expect.objectContaining({ 
           type: "initialized",
           actualVideoCodec: expect.stringContaining(".hw-test")
-        }),
-        undefined
+        })
       );
       consoleWarnSpy.mockRestore();
     });
@@ -964,8 +933,7 @@ describe("worker", () => {
         expect.objectContaining({ 
           type: "initialized",
           actualVideoCodec: expect.stringMatching(/\.no-pref-fallback$|^avc1\./)
-        }),
-        undefined
+        })
       );
       consoleWarnSpy.mockRestore();
     });
@@ -1000,7 +968,6 @@ describe("worker", () => {
             type: "not-supported",
           }),
         },
-        undefined,
       );
       consoleWarnSpy.mockRestore();
     });

--- a/test/worker-video.test.ts
+++ b/test/worker-video.test.ts
@@ -145,7 +145,6 @@ describe("handleAddVideoFrame", () => {
           stack: expect.any(String),
         },
       },
-      undefined,
     );
   });
 
@@ -180,7 +179,6 @@ describe("handleAddVideoFrame", () => {
         processedFrames: 1,
         totalFrames: 10,
       },
-      undefined,
     );
     expect(mockSelf.postMessage).toHaveBeenCalledWith(
       {
@@ -188,7 +186,6 @@ describe("handleAddVideoFrame", () => {
         videoQueueSize: 0,
         audioQueueSize: 0,
       },
-      undefined,
     );
     videoFrame.close();
   });


### PR DESCRIPTION
## Summary
- add typed helpers for retrieving `VideoEncoder`, `AudioEncoder`, and `AudioData`
- use the new types and drop many `as any` casts in encoder and worker
- adjust worker messaging to skip undefined transfer lists
- update tests to expect stricter typing

## Testing
- `npm run format`
- `npm run lint:fix`
- `npm run type-check`
- `npm test`